### PR TITLE
Add methods ITrinket#onEquipServer and ITrinket#onUnequipServer

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -6,16 +6,18 @@ import dev.emi.trinkets.api.SlotGroups;
 import dev.emi.trinkets.api.Slots;
 import dev.emi.trinkets.api.TrinketSlots;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.TrinketInventory;
 import nerdhub.cardinal.components.api.event.EntityComponentCallback;
 import nerdhub.cardinal.components.api.util.EntityComponents;
 import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 
 public class TrinketsMain implements ModInitializer {
-	
+	public static final Identifier ITEM_EQUIPPED_CHANGE_PACKET = new Identifier("trinkets", "item_equipped_change_packet");
 	@Override
 	public void onInitialize() {
 		EntityComponentCallback.event(PlayerEntity.class).register((player, components) -> components.put(TrinketsApi.TRINKETS, new PlayerTrinketComponent(player)));
@@ -26,13 +28,14 @@ public class TrinketsMain implements ModInitializer {
 			}
 			return ((ITrinket) stack.getItem()).canWearInSlot(slot.getSlotGroup().getName(), slot.getName());
 		});
+		ServerSidePacketRegistry.INSTANCE.register(ITEM_EQUIPPED_CHANGE_PACKET, TrinketInventory.EQUIP_STACK_HANDLER);
 		//Slots used for testing
-		//TrinketSlots.addSlot("head", "mask", new Identifier("trinkets", "textures/item/empty_trinket_slot_mask.png"));
-		//TrinketSlots.addSlot("chest", "necklace", new Identifier("trinkets", "textures/item/empty_trinket_slot_necklace.png"));
-		//TrinketSlots.addSlot("legs", "belt", new Identifier("trinkets", "textures/item/empty_trinket_slot_belt.png"));
-		//TrinketSlots.addSlot("feet", "aglet", new Identifier("trinkets", "textures/item/empty_trinket_slot_aglet.png"));
-		//TrinketSlots.addSlot("hand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
-		//TrinketSlots.addSlot("hand", "gloves", new Identifier("trinkets", "textures/item/empty_trinket_slot_gloves.png"));
-		//TrinketSlots.addSlot("offhand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
+//		TrinketSlots.addSlot("head", "mask", new Identifier("trinkets", "textures/item/empty_trinket_slot_mask.png"));
+//		TrinketSlots.addSlot("chest", "necklace", new Identifier("trinkets", "textures/item/empty_trinket_slot_necklace.png"));
+//		TrinketSlots.addSlot("legs", "belt", new Identifier("trinkets", "textures/item/empty_trinket_slot_belt.png"));
+//		TrinketSlots.addSlot("feet", "aglet", new Identifier("trinkets", "textures/item/empty_trinket_slot_aglet.png"));
+//		TrinketSlots.addSlot("hand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
+//		TrinketSlots.addSlot("hand", "gloves", new Identifier("trinkets", "textures/item/empty_trinket_slot_gloves.png"));
+//		TrinketSlots.addSlot("offhand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -30,12 +30,12 @@ public class TrinketsMain implements ModInitializer {
 		});
 		ServerSidePacketRegistry.INSTANCE.register(ITEM_EQUIPPED_CHANGE_PACKET, TrinketInventory.EQUIP_STACK_HANDLER);
 		//Slots used for testing
-//		TrinketSlots.addSlot("head", "mask", new Identifier("trinkets", "textures/item/empty_trinket_slot_mask.png"));
-//		TrinketSlots.addSlot("chest", "necklace", new Identifier("trinkets", "textures/item/empty_trinket_slot_necklace.png"));
-//		TrinketSlots.addSlot("legs", "belt", new Identifier("trinkets", "textures/item/empty_trinket_slot_belt.png"));
-//		TrinketSlots.addSlot("feet", "aglet", new Identifier("trinkets", "textures/item/empty_trinket_slot_aglet.png"));
-//		TrinketSlots.addSlot("hand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
-//		TrinketSlots.addSlot("hand", "gloves", new Identifier("trinkets", "textures/item/empty_trinket_slot_gloves.png"));
-//		TrinketSlots.addSlot("offhand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
+		//TrinketSlots.addSlot("head", "mask", new Identifier("trinkets", "textures/item/empty_trinket_slot_mask.png"));
+		//TrinketSlots.addSlot("chest", "necklace", new Identifier("trinkets", "textures/item/empty_trinket_slot_necklace.png"));
+		//TrinketSlots.addSlot("legs", "belt", new Identifier("trinkets", "textures/item/empty_trinket_slot_belt.png"));
+		//TrinketSlots.addSlot("feet", "aglet", new Identifier("trinkets", "textures/item/empty_trinket_slot_aglet.png"));
+		//TrinketSlots.addSlot("hand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
+		//TrinketSlots.addSlot("hand", "gloves", new Identifier("trinkets", "textures/item/empty_trinket_slot_gloves.png"));
+		//TrinketSlots.addSlot("offhand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/ITrinket.java
+++ b/src/main/java/dev/emi/trinkets/api/ITrinket.java
@@ -58,15 +58,27 @@ public interface ITrinket {
 	}
 
 	/**
-	 * Called when equipped by a player
+	 * Called when equipped by a player (Only called on client side)
 	 */
 	public default void onEquip(PlayerEntity player, ItemStack stack) {
 	}
 
 	/**
-	 * Called when unequipped by a player
+	 * Called when unequipped by a player (Only called on client side)
 	 */
 	public default void onUnequip(PlayerEntity player, ItemStack stack) {
+	}
+
+	/**
+	 * Called when equipped by a player (Only called on server side)
+	 */
+	public default void onEquipServer(PlayerEntity player, ItemStack stack) {
+	}
+
+	/**
+	 * Called when unequipped by a player (Only called on server side)
+	 */
+	public default void onUnequipServer(PlayerEntity player, ItemStack stack) {
 	}
 
 	/**

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -1,8 +1,13 @@
 package dev.emi.trinkets.api;
 
+import dev.emi.trinkets.TrinketsMain;
+import io.netty.buffer.Unpooled;
+import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.network.PacketConsumer;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.BasicInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.PacketByteBuf;
 
 /**
  * Inventory that marks its parent PlayerTrinketComponent dirty and syncs with the server when needed
@@ -22,18 +27,18 @@ public class TrinketInventory extends BasicInventory {
 	@Override
 	public void setInvStack(int i, ItemStack stack) {
 		if (getInvStack(i).getItem() instanceof ITrinket) {
-			((ITrinket) getInvStack(i).getItem()).onUnequip((PlayerEntity) component.getEntity(), getInvStack(i));
+			onUnEquipItemStack(getInvStack(i), (PlayerEntity) component.getEntity());
 		}
 		super.setInvStack(i, stack);
 		if(getInvStack(i).getItem() instanceof ITrinket) {
-			((ITrinket) getInvStack(i).getItem()).onEquip((PlayerEntity) component.getEntity(), getInvStack(i));
+			onEquipItemStack(getInvStack(i), (PlayerEntity) component.getEntity());
 		}
 	}
 
 	@Override
 	public ItemStack removeInvStack(int i) {
 		if(getInvStack(i).getItem() instanceof ITrinket){
-			((ITrinket) getInvStack(i).getItem()).onUnequip((PlayerEntity) component.getEntity(), getInvStack(i));
+			onUnEquipItemStack(getInvStack(i), (PlayerEntity) component.getEntity());
 		}
 		return super.removeInvStack(i);
 	}
@@ -42,7 +47,7 @@ public class TrinketInventory extends BasicInventory {
 	public ItemStack takeInvStack(int i, int count) {
 		ItemStack stack = super.takeInvStack(i, count);
 		if (!stack.isEmpty() && getInvStack(i).isEmpty() && stack.getItem() instanceof ITrinket) {
-			((ITrinket) stack.getItem()).onUnequip((PlayerEntity) component.getEntity(), stack);
+			onUnEquipItemStack(stack, (PlayerEntity) component.getEntity());
 		}
 		return stack;
 	}
@@ -51,4 +56,35 @@ public class TrinketInventory extends BasicInventory {
 	public void markDirty() {
 		component.markDirty();
 	}
+
+	private void onEquipItemStack(ItemStack stack, PlayerEntity player) {
+		((ITrinket) stack.getItem()).onEquip(player, stack);
+		PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
+		passedData.writeBoolean(true); // Equipping, not unequipping
+		passedData.writeItemStack(stack);
+		ClientSidePacketRegistry.INSTANCE.sendToServer(TrinketsMain.ITEM_EQUIPPED_CHANGE_PACKET, passedData);
+	}
+
+	private void onUnEquipItemStack(ItemStack stack, PlayerEntity player) {
+		((ITrinket) stack.getItem()).onUnequip(player, stack);
+		PacketByteBuf passedData = new PacketByteBuf(Unpooled.buffer());
+		passedData.writeBoolean(false); // Unequipping, not equipping
+		passedData.writeItemStack(stack);
+		ClientSidePacketRegistry.INSTANCE.sendToServer(TrinketsMain.ITEM_EQUIPPED_CHANGE_PACKET, passedData);
+	}
+
+	public static PacketConsumer EQUIP_STACK_HANDLER = ((packetContext, data) -> {
+		boolean isEquipping = data.readBoolean();
+		ItemStack stack = data.readItemStack();
+		PlayerEntity player = packetContext.getPlayer();
+		if (!(stack.getItem() instanceof ITrinket)) return;
+		ITrinket trinket = (ITrinket) stack.getItem();
+		packetContext.getTaskQueue().execute(() -> {
+			if (isEquipping) {
+				trinket.onEquipServer(player, stack);
+			} else {
+				trinket.onUnequipServer(player, stack);
+			}
+		});
+	});
 }


### PR DESCRIPTION
ITrinket#onEquip and ITrinket#onUnequip are only called on the client side, which makes making items that modify the player when they are equipped much more difficult. This fix shouldn't break backwards compatibility, as ITrinket#onEquipServer and ITrinket#onUnequipServer are both defaulted methods, with an empty default implementation, like ITrinket#onEquip and ITrinket#onUnequip. The documentation comments for ITrinket#onEquip and ITrinket#onUnequip have also been updated to make this divide clearer.