### PR TITLE
Fix for dispensers chewing up items

### DIFF
--- a/src/main/java/dev/emi/trinkets/api/TrinketItem.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketItem.java
@@ -22,19 +22,18 @@ public abstract class TrinketItem extends Item implements Trinket {
 	public static final DispenserBehavior TRINKET_DISPENSER_BEHAVIOR = new ItemDispenserBehavior() {
 		protected ItemStack dispenseSilently(BlockPointer pointer, ItemStack stack) {
 			BlockPos pos = pointer.getBlockPos().offset((Direction) pointer.getBlockState().get(DispenserBlock.FACING));
-			List<LivingEntity> entities = pointer.getWorld().getEntities(LivingEntity.class, new Box(pos), EntityPredicates.EXCEPT_SPECTATOR.and(new EntityPredicates.CanPickup(stack)));
-			if (entities.isEmpty()) {
-				return ItemStack.EMPTY;
-			} else {
-				LivingEntity entity = (LivingEntity) entities.get(0);
-				if(entity instanceof PlayerEntity) {
-					TrinketComponent comp = TrinketsApi.getTrinketComponent((PlayerEntity) entity);
-					if(comp.equip(stack)) {
-						stack.setCount(0);
+			List<LivingEntity> entities = pointer.getWorld().getEntities(LivingEntity.class, new Box(pos), EntityPredicates.EXCEPT_SPECTATOR.and(new EntityPredicates.CanPickup(stack)));if (!entities.isEmpty()) {
+				LivingEntity entity = entities.get(0);
+				if (entity instanceof PlayerEntity) {
+					TrinketComponent comp = TrinketsApi.getTrinketComponent((PlayerEntity)entity);
+					ItemStack test = stack.copy().split(1);
+					if (comp.equip(test)) {
+						stack.decrement(1);
+						return stack;
 					}
 				}
 			}
-			return stack.isEmpty() ? super.dispenseSilently(pointer, stack) : stack;
+			return super.dispenseSilently(pointer, stack);
 		}
 	};
 

--- a/src/main/java/dev/emi/trinkets/mixin/ElytraItemMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/ElytraItemMixin.java
@@ -1,14 +1,12 @@
 package dev.emi.trinkets.mixin;
 
+import dev.emi.trinkets.api.*;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import dev.emi.trinkets.api.TrinketItem;
-import dev.emi.trinkets.api.TrinketComponent;
-import dev.emi.trinkets.api.TrinketsApi;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.dispenser.DispenserBehavior;
 import net.minecraft.entity.player.PlayerEntity;
@@ -24,7 +22,7 @@ import net.minecraft.world.World;
  * Changes dispenser and right click equipping to use trinket slots
  */
 @Mixin(ElytraItem.class)
-public abstract class ElytraItemMixin {
+public abstract class ElytraItemMixin implements Trinket {
 
 	@Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/DispenserBlock;registerBehavior(Lnet/minecraft/item/ItemConvertible;Lnet/minecraft/block/dispenser/DispenserBehavior;)V"), method = "<init>")
 	private void registerBehaviorProxy(ItemConvertible item, DispenserBehavior behavior) {
@@ -42,4 +40,8 @@ public abstract class ElytraItemMixin {
 			info.setReturnValue(new TypedActionResult<ItemStack>(ActionResult.FAIL, stack));
 		}
 	 }
+
+	public boolean canWearInSlot(String group, String slot) {
+		return group.equals(SlotGroups.CHEST) && slot.equals(Slots.CAPE);
+	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerEntityMixin.java
@@ -102,7 +102,7 @@ public abstract class PlayerEntityMixin extends LivingEntity {
 			for (TrinketSlots.Slot slot : TrinketSlots.getAllSlots()) {
 				if (slot.canEquip.apply(slot, stack)) {
 					cir.setReturnValue(comp.getStack(slot.getName()).isEmpty());
-					return;
+					cir.cancel();
 				}
 			}
 		}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerEntityMixin.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import com.google.common.collect.Multimap;
 
 import net.minecraft.entity.attribute.EntityAttribute;
-import net.minecraft.item.SuspiciousStewItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerEntityMixin.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import com.google.common.collect.Multimap;
 
 import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.item.SuspiciousStewItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -30,6 +31,7 @@ import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 /**
  * Drops trinkets on death if other items are dropping, elytra check redirect, and handling attributes
@@ -90,6 +92,19 @@ public abstract class PlayerEntityMixin extends LivingEntity {
 					addAttributes((PlayerEntity) (LivingEntity) this, current, i);
 				}
 				oldStacks.set(i, current.copy());
+			}
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "canPickUp(Lnet/minecraft/item/ItemStack;)Z", cancellable = true)
+	public void canPickUp(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+		if (stack.getItem() instanceof Trinket) {
+			TrinketComponent comp = TrinketsApi.getTrinketComponent((PlayerEntity) (LivingEntity) this);
+			for (TrinketSlots.Slot slot : TrinketSlots.getAllSlots()) {
+				if (slot.canEquip.apply(slot, stack)) {
+					cir.setReturnValue(comp.getStack(slot.getName()).isEmpty());
+					return;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Previously, the included dispenser behaviour for TrinketItem would chew up the stack upon failure to find a valid entity to pick up the trinket, as well as completely empty a stack when dispensing a stackable trinket - this was fixed to dispense only one item from a stack a time and fire it from the dispenser upon failure to find a target. In addition, this fixes trinket slots not being considered when trying to find a spot to equip, and so failing when the inventory is full even if the trinket slot is open - this fix kicks in for any item implementing Trinket, so I also made ElytraItem do so to avoid having to make an exception for it.