### PR TITLE
Basic data-driven slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bin/
 # fabric
 
 run/
+logs/

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -5,7 +5,7 @@ import net.fabricmc.api.ClientModInitializer;
 public class TrinketsClient implements ClientModInitializer {
 
 	@Override
-	public void onInitializeClient(){
+	public void onInitializeClient() {
 
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,11 +1,19 @@
 package dev.emi.trinkets;
 
+import dev.emi.trinkets.data.SlotLoader;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.minecraft.resource.ResourceType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TrinketsMain implements ModInitializer {
-	
-	@Override
-	public void onInitialize() {
-		
-	}
+
+  public static final String MOD_ID = "trinkets";
+  public static final Logger LOGGER = LogManager.getLogger();
+
+  @Override
+  public void onInitialize() {
+    ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(SlotLoader.INSTANCE);
+  }
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -18,22 +18,22 @@ import org.apache.logging.log4j.Logger;
 
 public class TrinketsMain implements ModInitializer, EntityComponentInitializer {
 
-  public static final String MOD_ID = "trinkets";
-  public static final Logger LOGGER = LogManager.getLogger();
+	public static final String MOD_ID = "trinkets";
+	public static final Logger LOGGER = LogManager.getLogger();
 
-  public static final ComponentKey<TrinketComponent> TRINKETS = ComponentRegistryV3.INSTANCE
-      .getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
+	public static final ComponentKey<TrinketComponent> TRINKETS = ComponentRegistryV3.INSTANCE
+			.getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
+
+	@Override
+	public void onInitialize() {
+		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper
+				.get(ResourceType.SERVER_DATA);
+		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
+		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
+	}
 
   @Override
-  public void onInitialize() {
-    ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper
-        .get(ResourceType.SERVER_DATA);
-    resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
-    resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
-  }
-
-  @Override
-  public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
-    registry.registerFor(LivingEntity.class, TRINKETS, LivingEntityTrinketComponent::new);
-  }
+	public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
+		registry.registerFor(LivingEntity.class, TRINKETS, LivingEntityTrinketComponent::new);
+	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,28 +1,28 @@
 package dev.emi.trinkets;
 
-import dev.emi.trinkets.data.EntitySlotLoader;
-import dev.emi.trinkets.data.SlotLoader;
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.data.EntitySlotLoader;
+import dev.emi.trinkets.data.SlotLoader;
 import dev.onyxstudios.cca.api.v3.component.ComponentKey;
 import dev.onyxstudios.cca.api.v3.component.ComponentRegistryV3;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
-import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.resource.ResourceType;
+import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.util.Identifier;
 
 public class TrinketsMain implements ModInitializer, EntityComponentInitializer {
 
   public static final String MOD_ID = "trinkets";
   public static final Logger LOGGER = LogManager.getLogger();
 
-	public static final ComponentKey<TrinketComponent> TRINKETS = ComponentRegistryV3.INSTANCE.getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
+  public static final ComponentKey<TrinketComponent> TRINKETS = ComponentRegistryV3.INSTANCE
+      .getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
 
   @Override
   public void onInitialize() {
@@ -32,10 +32,8 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
     resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
   }
 
-	@Override
-	public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
-		registry.registerFor(LivingEntity.class, TRINKETS, entity -> {
-			return new LivingEntityTrinketComponent(entity);
-		});
-	}
+  @Override
+  public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
+    registry.registerFor(LivingEntity.class, TRINKETS, LivingEntityTrinketComponent::new);
+  }
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,5 +1,6 @@
 package dev.emi.trinkets;
 
+import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.emi.trinkets.data.SlotLoader;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
@@ -14,6 +15,9 @@ public class TrinketsMain implements ModInitializer {
 
   @Override
   public void onInitialize() {
-    ResourceManagerHelper.get(ResourceType.SERVER_DATA).registerReloadListener(SlotLoader.INSTANCE);
+    ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper
+        .get(ResourceType.SERVER_DATA);
+    resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
+    resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
   }
 }

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -5,6 +5,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.nbt.CompoundTag;
 
 public class LivingEntityTrinketComponent implements TrinketComponent, AutoSyncedComponent {
+
 	public LivingEntity entity;
 
 	public LivingEntityTrinketComponent(LivingEntity entity) {
@@ -18,6 +19,6 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 
 	@Override
 	public void writeToNbt(CompoundTag tag) {
-		
+
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotGroup.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotGroup.java
@@ -1,43 +1,43 @@
 package dev.emi.trinkets.api;
 
-import com.ibm.icu.impl.locale.XCldrStub.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
 
 public final class SlotGroup {
 
-  private final String defaultSlot;
-  private final Map<String, SlotType> slots;
+	private final String defaultSlot;
+	private final Map<String, SlotType> slots;
 
-  private SlotGroup(Builder builder) {
-    this.defaultSlot = builder.defaultSlot;
-    this.slots = builder.slots;
-  }
+	private SlotGroup(Builder builder) {
+		this.defaultSlot = builder.defaultSlot;
+		this.slots = builder.slots;
+	}
 
-  public String getDefaultSlot() {
-    return defaultSlot;
-  }
+	public String getDefaultSlot() {
+		return defaultSlot;
+	}
 
-  public Map<String, SlotType> getSlots() {
-    return ImmutableMap.copyOf(slots);
-  }
+	public Map<String, SlotType> getSlots() {
+		return ImmutableMap.copyOf(slots);
+	}
 
-  public static class Builder {
+	public static class Builder {
 
-    private final String defaultSlot;
-    private final Map<String, SlotType> slots = new HashMap<>();
+		private final String defaultSlot;
+		private final Map<String, SlotType> slots = new HashMap<>();
 
-    public Builder(String defaultSlot) {
-      this.defaultSlot = defaultSlot;
-    }
+		public Builder(String defaultSlot) {
+			this.defaultSlot = defaultSlot;
+		}
 
-    public Builder addSlot(String name, SlotType slot) {
-      this.slots.put(name, slot);
-      return this;
-    }
+		public Builder addSlot(String name, SlotType slot) {
+			this.slots.put(name, slot);
+			return this;
+		}
 
-    public SlotGroup build() {
-      return new SlotGroup(this);
-    }
-  }
+		public SlotGroup build() {
+			return new SlotGroup(this);
+		}
+	}
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotGroup.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotGroup.java
@@ -1,0 +1,43 @@
+package dev.emi.trinkets.api;
+
+import com.ibm.icu.impl.locale.XCldrStub.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SlotGroup {
+
+  private final String defaultSlot;
+  private final Map<String, SlotType> slots;
+
+  private SlotGroup(Builder builder) {
+    this.defaultSlot = builder.defaultSlot;
+    this.slots = builder.slots;
+  }
+
+  public String getDefaultSlot() {
+    return defaultSlot;
+  }
+
+  public Map<String, SlotType> getSlots() {
+    return ImmutableMap.copyOf(slots);
+  }
+
+  public static class Builder {
+
+    private final String defaultSlot;
+    private final Map<String, SlotType> slots = new HashMap<>();
+
+    public Builder(String defaultSlot) {
+      this.defaultSlot = defaultSlot;
+    }
+
+    public Builder addSlot(String name, SlotType slot) {
+      this.slots.put(name, slot);
+      return this;
+    }
+
+    public SlotGroup build() {
+      return new SlotGroup(this);
+    }
+  }
+}

--- a/src/main/java/dev/emi/trinkets/api/SlotType.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotType.java
@@ -6,56 +6,56 @@ import net.minecraft.util.Identifier;
 
 public class SlotType {
 
-  private final String name;
-  private final int order;
-  private final int amount;
-  private final int locked;
-  private final Identifier icon;
-  private final boolean transferable;
-  private final Set<Identifier> validators;
-  private final DropRule dropRule;
+	private final String name;
+	private final int order;
+	private final int amount;
+	private final int locked;
+	private final Identifier icon;
+	private final boolean transferable;
+	private final Set<Identifier> validators;
+	private final DropRule dropRule;
 
-  public SlotType(String name, int order, int amount, int locked, Identifier icon,
-      boolean transferable, Set<Identifier> validators, DropRule dropRule) {
-    this.name = name;
-    this.order = order;
-    this.amount = amount;
-    this.locked = locked;
-    this.icon = icon;
-    this.transferable = transferable;
-    this.validators = validators;
-    this.dropRule = dropRule;
-  }
+	public SlotType(String name, int order, int amount, int locked, Identifier icon,
+			boolean transferable, Set<Identifier> validators, DropRule dropRule) {
+		this.name = name;
+		this.order = order;
+		this.amount = amount;
+		this.locked = locked;
+		this.icon = icon;
+		this.transferable = transferable;
+		this.validators = validators;
+		this.dropRule = dropRule;
+	}
 
-  public String getName() {
-    return name;
-  }
+	public String getName() {
+		return name;
+	}
 
-  public int getOrder() {
-    return order;
-  }
+	public int getOrder() {
+		return order;
+	}
 
-  public int getAmount() {
-    return amount;
-  }
+	public int getAmount() {
+		return amount;
+	}
 
-  public int getLocked() {
-    return locked;
-  }
+	public int getLocked() {
+		return locked;
+	}
 
-  public Identifier getIcon() {
-    return icon;
-  }
+	public Identifier getIcon() {
+		return icon;
+	}
 
-  public boolean isTransferable() {
-    return transferable;
-  }
+	public boolean isTransferable() {
+		return transferable;
+	}
 
-  public Set<Identifier> getValidators() {
-    return validators;
-  }
+	public Set<Identifier> getValidators() {
+		return validators;
+	}
 
-  public DropRule getDropRule() {
-    return dropRule;
-  }
+	public DropRule getDropRule() {
+		return dropRule;
+	}
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotType.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotType.java
@@ -1,0 +1,61 @@
+package dev.emi.trinkets.api;
+
+import dev.emi.trinkets.api.TrinketEnums.DropRule;
+import java.util.Set;
+import net.minecraft.util.Identifier;
+
+public class SlotType {
+
+  private final String name;
+  private final int order;
+  private final int amount;
+  private final int locked;
+  private final Identifier icon;
+  private final boolean transferable;
+  private final Set<Identifier> validators;
+  private final DropRule dropRule;
+
+  public SlotType(String name, int order, int amount, int locked, Identifier icon,
+      boolean transferable, Set<Identifier> validators, DropRule dropRule) {
+    this.name = name;
+    this.order = order;
+    this.amount = amount;
+    this.locked = locked;
+    this.icon = icon;
+    this.transferable = transferable;
+    this.validators = validators;
+    this.dropRule = dropRule;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getOrder() {
+    return order;
+  }
+
+  public int getAmount() {
+    return amount;
+  }
+
+  public int getLocked() {
+    return locked;
+  }
+
+  public Identifier getIcon() {
+    return icon;
+  }
+
+  public boolean isTransferable() {
+    return transferable;
+  }
+
+  public Set<Identifier> getValidators() {
+    return validators;
+  }
+
+  public DropRule getDropRule() {
+    return dropRule;
+  }
+}

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -1,10 +1,8 @@
 package dev.emi.trinkets.api;
 
-import java.util.Optional;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-
+import java.util.Optional;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttribute;
@@ -25,16 +23,16 @@ public interface Trinket {
 
 	/**
 	 * Called when an entity equips a trinket
-	 * 
-	 * @param stack		The stack being equipped
+	 *
+	 * @param stack The stack being equipped
 	 */
 	public default void onEquip(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
 	}
-	
+
 	/**
 	 * Called when an entity equips a trinket
-	 * 
-	 * @param stack		The stack being unequipped
+	 *
+	 * @param stack The stack being unequipped
 	 */
 	public default void onUnequip(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
 	}
@@ -48,22 +46,26 @@ public interface Trinket {
 	}
 
 	/**
-	 * Returns the Entity Attribute Modifiers for a stack in a slot.
-	 * Super implementations should remain pure
+	 * Returns the Entity Attribute Modifiers for a stack in a slot. Super implementations should
+	 * remain pure
 	 */
-	public default Multimap<EntityAttribute, EntityAttributeModifier> getModifiers(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default Multimap<EntityAttribute, EntityAttributeModifier> getModifiers(ItemStack stack,
+			TrinketSlot slot, LivingEntity entity) {
 		Multimap<EntityAttribute, EntityAttributeModifier> map = HashMultimap.create();
 		if (stack.hasTag() && stack.getTag().contains("TrinketAttributeModifiers", 9)) {
 			ListTag list = stack.getTag().getList("TrinketAttributeModifiers", 10);
 
-			for(int i = 0; i < list.size(); ++i) {
+			for (int i = 0; i < list.size(); ++i) {
 				CompoundTag tag = list.getCompound(i);
 				// TODO Determine and setup a slot naming scheme for tags, probably just group:slot, and uncomment the second condition
 				if (!tag.contains("Slot", 8)/* || tag.getString("Slot").equals(equipmentSlot.getName())*/) {
-					Optional<EntityAttribute> optional = Registry.ATTRIBUTE.getOrEmpty(Identifier.tryParse(tag.getString("AttributeName")));
+					Optional<EntityAttribute> optional = Registry.ATTRIBUTE
+							.getOrEmpty(Identifier.tryParse(tag.getString("AttributeName")));
 					if (optional.isPresent()) {
 						EntityAttributeModifier entityAttributeModifier = EntityAttributeModifier.fromTag(tag);
-						if (entityAttributeModifier != null && entityAttributeModifier.getId().getLeastSignificantBits() != 0L && entityAttributeModifier.getId().getMostSignificantBits() != 0L) {
+						if (entityAttributeModifier != null
+								&& entityAttributeModifier.getId().getLeastSignificantBits() != 0L
+								&& entityAttributeModifier.getId().getMostSignificantBits() != 0L) {
 							map.put(optional.get(), entityAttributeModifier);
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
@@ -3,5 +3,5 @@ package dev.emi.trinkets.api;
 import dev.onyxstudios.cca.api.v3.component.ComponentV3;
 
 public interface TrinketComponent extends ComponentV3 {
-	
+
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketEnums.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketEnums.java
@@ -1,0 +1,20 @@
+package dev.emi.trinkets.api;
+
+public class TrinketEnums {
+
+  public enum DropRule {
+    ALWAYS_KEEP, ALWAYS_DROP, DEFAULT, DESTROY;
+
+    static public boolean has(String name) {
+      DropRule[] rules = DropRule.values();
+
+      for (DropRule rule : rules) {
+
+        if (rule.toString().equals(name)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/src/main/java/dev/emi/trinkets/api/TrinketEnums.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketEnums.java
@@ -2,19 +2,19 @@ package dev.emi.trinkets.api;
 
 public class TrinketEnums {
 
-  public enum DropRule {
-    ALWAYS_KEEP, ALWAYS_DROP, DEFAULT, DESTROY;
+	public enum DropRule {
+		ALWAYS_KEEP, ALWAYS_DROP, DEFAULT, DESTROY;
 
-    static public boolean has(String name) {
-      DropRule[] rules = DropRule.values();
+		static public boolean has(String name) {
+			DropRule[] rules = DropRule.values();
 
-      for (DropRule rule : rules) {
+			for (DropRule rule : rules) {
 
-        if (rule.toString().equals(name)) {
-          return true;
-        }
-      }
-      return false;
-    }
-  }
+				if (rule.toString().equals(name)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketSlots.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketSlots.java
@@ -1,0 +1,16 @@
+package dev.emi.trinkets.api;
+
+import dev.emi.trinkets.data.EntitySlotLoader;
+import java.util.Map;
+import net.minecraft.entity.EntityType;
+
+public class TrinketSlots {
+
+  public static Map<String, SlotGroup> getPlayerSlots() {
+    return EntitySlotLoader.INSTANCE.getPlayerSlots();
+  }
+
+  public static Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
+    return EntitySlotLoader.INSTANCE.getEntitySlots(entityType);
+  }
+}

--- a/src/main/java/dev/emi/trinkets/api/TrinketSlots.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketSlots.java
@@ -6,11 +6,11 @@ import net.minecraft.entity.EntityType;
 
 public class TrinketSlots {
 
-  public static Map<String, SlotGroup> getPlayerSlots() {
-    return EntitySlotLoader.INSTANCE.getPlayerSlots();
-  }
+	public static Map<String, SlotGroup> getPlayerSlots() {
+		return EntitySlotLoader.INSTANCE.getPlayerSlots();
+	}
 
-  public static Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
-    return EntitySlotLoader.INSTANCE.getEntitySlots(entityType);
-  }
+	public static Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
+		return EntitySlotLoader.INSTANCE.getEntitySlots(entityType);
+	}
 }

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -1,0 +1,134 @@
+package dev.emi.trinkets.data;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.SlotGroup;
+import dev.emi.trinkets.data.SlotLoader.GroupData;
+import dev.emi.trinkets.data.SlotLoader.SlotData;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.minecraft.entity.EntityType;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.SinglePreparationResourceReloadListener;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.profiler.Profiler;
+import net.minecraft.util.registry.Registry;
+
+public class EntitySlotLoader extends
+    SinglePreparationResourceReloadListener<Map<String, Map<String, SlotGroup>>> implements
+    IdentifiableResourceReloadListener {
+
+  public static final EntitySlotLoader INSTANCE = new EntitySlotLoader();
+
+  private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
+      .create();
+  private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "entities");
+
+  private Map<String, SlotGroup> playerSlots = new HashMap<>();
+  private Map<EntityType<?>, Map<String, SlotGroup>> entitySlots = new HashMap<>();
+
+  @Override
+  protected Map<String, Map<String, SlotGroup>> prepare(ResourceManager resourceManager,
+      Profiler profiler) {
+    Map<String, Map<String, SlotGroup>> map = new HashMap<>();
+    String dataType = "entities";
+
+    for (Identifier identifier : resourceManager
+        .findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
+      try {
+        InputStreamReader reader = new InputStreamReader(
+            resourceManager.getResource(identifier).getInputStream());
+        JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
+
+        if (jsonObject != null) {
+          boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);
+          JsonArray assignedSlots = JsonHelper.getArray(jsonObject, "slots", new JsonArray());
+          Map<String, GroupData> slots = SlotLoader.INSTANCE.getSlots();
+          Map<String, SlotGroup.Builder> groupBuilders = new HashMap<>();
+
+          if (assignedSlots != null) {
+
+            for (JsonElement assignedSlot : assignedSlots) {
+              String[] parsedSlot = assignedSlot.getAsString().split("/", 2);
+              String group = parsedSlot[0];
+              String name = parsedSlot[1];
+              GroupData groupData = slots.get(group);
+
+              if (groupData != null) {
+                SlotGroup.Builder builder = groupBuilders.computeIfAbsent(group,
+                    (k) -> new SlotGroup.Builder(groupData.getDefaultSlot()));
+                SlotData slotData = groupData.getSlot(name);
+
+                if (slotData != null) {
+                  builder.addSlot(name, slotData.create(name));
+                }
+              }
+            }
+          }
+          JsonArray entities = JsonHelper.getArray(jsonObject, "entities", new JsonArray());
+
+          if (!groupBuilders.isEmpty() && entities != null) {
+
+            for (JsonElement entity : entities) {
+              String name = entity.getAsString();
+              Map<String, SlotGroup> createdEntitySlots = map
+                  .computeIfAbsent(name, (k) -> new HashMap<>());
+
+              if (replace) {
+                createdEntitySlots.clear();
+              }
+              groupBuilders.forEach((groupName, builder) -> createdEntitySlots
+                  .putIfAbsent(groupName, builder.build()));
+            }
+          }
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    return map;
+  }
+
+  @Override
+  protected void apply(Map<String, Map<String, SlotGroup>> loader, ResourceManager manager,
+      Profiler profiler) {
+    loader.forEach((entityName, groups) -> {
+      if (entityName.equals("player")) {
+        this.playerSlots.putAll(groups);
+      } else {
+        Registry.ENTITY_TYPE.getOrEmpty(new Identifier(entityName))
+            .ifPresent(entityType -> this.entitySlots.putIfAbsent(entityType, groups));
+      }
+    });
+    TrinketsMain.LOGGER.info("Done");
+  }
+
+  public Map<String, SlotGroup> getPlayerSlots() {
+    return ImmutableMap.copyOf(this.playerSlots);
+  }
+
+  public Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
+    return ImmutableMap.copyOf(this.entitySlots.get(entityType));
+  }
+
+  @Override
+  public Identifier getFabricId() {
+    return ID;
+  }
+
+  @Override
+  public Collection<Identifier> getFabricDependencies() {
+    return Collections.singletonList(SlotLoader.ID);
+  }
+}

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -28,125 +28,125 @@ import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.Registry;
 
 public class EntitySlotLoader extends
-    SinglePreparationResourceReloadListener<Map<String, Map<String, Set<String>>>> implements
-    IdentifiableResourceReloadListener {
+		SinglePreparationResourceReloadListener<Map<String, Map<String, Set<String>>>> implements
+		IdentifiableResourceReloadListener {
 
-  public static final EntitySlotLoader INSTANCE = new EntitySlotLoader();
+	public static final EntitySlotLoader INSTANCE = new EntitySlotLoader();
 
-  private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
-      .create();
-  private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "entities");
+	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
+			.create();
+	private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "entities");
 
-  private Map<String, SlotGroup> playerSlots = new HashMap<>();
-  private Map<EntityType<?>, Map<String, SlotGroup>> entitySlots = new HashMap<>();
+	private Map<String, SlotGroup> playerSlots = new HashMap<>();
+	private Map<EntityType<?>, Map<String, SlotGroup>> entitySlots = new HashMap<>();
 
-  @Override
-  protected Map<String, Map<String, Set<String>>> prepare(ResourceManager resourceManager,
-      Profiler profiler) {
-    Map<String, Map<String, Set<String>>> map = new HashMap<>();
-    String dataType = "entities";
+	@Override
+	protected Map<String, Map<String, Set<String>>> prepare(ResourceManager resourceManager,
+			Profiler profiler) {
+		Map<String, Map<String, Set<String>>> map = new HashMap<>();
+		String dataType = "entities";
 
-    for (Identifier identifier : resourceManager
-        .findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
-      try {
-        InputStreamReader reader = new InputStreamReader(
-            resourceManager.getResource(identifier).getInputStream());
-        JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
+		for (Identifier identifier : resourceManager
+				.findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
+			try {
+				InputStreamReader reader = new InputStreamReader(
+						resourceManager.getResource(identifier).getInputStream());
+				JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
 
-        if (jsonObject != null) {
-          boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);
-          JsonArray assignedSlots = JsonHelper.getArray(jsonObject, "slots", new JsonArray());
-          Map<String, Set<String>> groups = new HashMap<>();
+				if (jsonObject != null) {
+					boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);
+					JsonArray assignedSlots = JsonHelper.getArray(jsonObject, "slots", new JsonArray());
+					Map<String, Set<String>> groups = new HashMap<>();
 
-          if (assignedSlots != null) {
+					if (assignedSlots != null) {
 
-            for (JsonElement assignedSlot : assignedSlots) {
-              String[] parsedSlot = assignedSlot.getAsString().split("/", 2);
-              String group = parsedSlot[0];
-              String name = parsedSlot[1];
-              groups.computeIfAbsent(group, (k) -> new HashSet<>()).add(name);
-            }
-          }
-          JsonArray entities = JsonHelper.getArray(jsonObject, "entities", new JsonArray());
+						for (JsonElement assignedSlot : assignedSlots) {
+							String[] parsedSlot = assignedSlot.getAsString().split("/", 2);
+							String group = parsedSlot[0];
+							String name = parsedSlot[1];
+							groups.computeIfAbsent(group, (k) -> new HashSet<>()).add(name);
+						}
+					}
+					JsonArray entities = JsonHelper.getArray(jsonObject, "entities", new JsonArray());
 
-          if (!groups.isEmpty() && entities != null) {
+					if (!groups.isEmpty() && entities != null) {
 
-            for (JsonElement entity : entities) {
-              String name = entity.getAsString();
-              Map<String, Set<String>> slots = map.computeIfAbsent(name, (k) -> new HashMap<>());
+						for (JsonElement entity : entities) {
+							String name = entity.getAsString();
+							Map<String, Set<String>> slots = map.computeIfAbsent(name, (k) -> new HashMap<>());
 
-              if (replace) {
-                slots.clear();
-              }
-              groups.forEach(
-                  (groupName, slotNames) -> slots.computeIfAbsent(groupName, (k) -> new HashSet<>())
-                      .addAll(slotNames));
-            }
-          }
-        }
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-    }
-    return map;
-  }
+							if (replace) {
+								slots.clear();
+							}
+							groups.forEach(
+									(groupName, slotNames) -> slots.computeIfAbsent(groupName, (k) -> new HashSet<>())
+											.addAll(slotNames));
+						}
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		return map;
+	}
 
-  @Override
-  protected void apply(Map<String, Map<String, Set<String>>> loader, ResourceManager manager,
-      Profiler profiler) {
-    Map<String, GroupData> slots = SlotLoader.INSTANCE.getSlots();
-    Map<String, Map<String, SlotGroup.Builder>> groupBuilders = new HashMap<>();
+	@Override
+	protected void apply(Map<String, Map<String, Set<String>>> loader, ResourceManager manager,
+			Profiler profiler) {
+		Map<String, GroupData> slots = SlotLoader.INSTANCE.getSlots();
+		Map<String, Map<String, SlotGroup.Builder>> groupBuilders = new HashMap<>();
 
-    loader.forEach((entityName, groups) -> {
-      Map<String, SlotGroup.Builder> builders = groupBuilders
-          .computeIfAbsent(entityName, (k) -> new HashMap<>());
-      groups.forEach((groupName, slotNames) -> {
-        GroupData group = slots.get(groupName);
+		loader.forEach((entityName, groups) -> {
+			Map<String, SlotGroup.Builder> builders = groupBuilders
+					.computeIfAbsent(entityName, (k) -> new HashMap<>());
+			groups.forEach((groupName, slotNames) -> {
+				GroupData group = slots.get(groupName);
 
-        if (group != null) {
-          SlotGroup.Builder builder = builders
-              .computeIfAbsent(groupName, (k) -> new SlotGroup.Builder(group.getDefaultSlot()));
-          slotNames.forEach(slotName -> {
-            SlotData slotData = group.getSlot(slotName);
+				if (group != null) {
+					SlotGroup.Builder builder = builders
+							.computeIfAbsent(groupName, (k) -> new SlotGroup.Builder(group.getDefaultSlot()));
+					slotNames.forEach(slotName -> {
+						SlotData slotData = group.getSlot(slotName);
 
-            if (slotData != null) {
-              builder.addSlot(slotName, slotData.create(slotName));
-            }
-          });
-        }
-      });
-    });
-    this.playerSlots.clear();
-    this.entitySlots.clear();
+						if (slotData != null) {
+							builder.addSlot(slotName, slotData.create(slotName));
+						}
+					});
+				}
+			});
+		});
+		this.playerSlots.clear();
+		this.entitySlots.clear();
 
-    groupBuilders.forEach((entityName, groups) -> {
-      Map<String, SlotGroup> existing = entityName.equals("player") ? this.playerSlots
-          : Registry.ENTITY_TYPE.getOrEmpty(new Identifier(entityName))
-              .map(type -> this.entitySlots.computeIfAbsent(type, (k) -> new HashMap<>()))
-              .orElse(null);
+		groupBuilders.forEach((entityName, groups) -> {
+			Map<String, SlotGroup> existing = entityName.equals("player") ? this.playerSlots
+					: Registry.ENTITY_TYPE.getOrEmpty(new Identifier(entityName))
+							.map(type -> this.entitySlots.computeIfAbsent(type, (k) -> new HashMap<>()))
+							.orElse(null);
 
-      if (existing != null) {
-        groups.forEach(
-            (groupName, groupBuilder) -> existing.putIfAbsent(groupName, groupBuilder.build()));
-      }
-    });
-  }
+			if (existing != null) {
+				groups.forEach(
+						(groupName, groupBuilder) -> existing.putIfAbsent(groupName, groupBuilder.build()));
+			}
+		});
+	}
 
-  public Map<String, SlotGroup> getPlayerSlots() {
-    return ImmutableMap.copyOf(this.playerSlots);
-  }
+	public Map<String, SlotGroup> getPlayerSlots() {
+		return ImmutableMap.copyOf(this.playerSlots);
+	}
 
-  public Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
-    return ImmutableMap.copyOf(this.entitySlots.get(entityType));
-  }
+	public Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
+		return ImmutableMap.copyOf(this.entitySlots.get(entityType));
+	}
 
-  @Override
-  public Identifier getFabricId() {
-    return ID;
-  }
+	@Override
+	public Identifier getFabricId() {
+		return ID;
+	}
 
-  @Override
-  public Collection<Identifier> getFabricDependencies() {
-    return Collections.singletonList(SlotLoader.ID);
-  }
+	@Override
+	public Collection<Identifier> getFabricDependencies() {
+		return Collections.singletonList(SlotLoader.ID);
+	}
 }

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -25,137 +25,137 @@ import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
 
 public class SlotLoader extends
-    SinglePreparationResourceReloadListener<Map<String, GroupData>> implements
-    IdentifiableResourceReloadListener {
+		SinglePreparationResourceReloadListener<Map<String, GroupData>> implements
+		IdentifiableResourceReloadListener {
 
-  public static final SlotLoader INSTANCE = new SlotLoader();
+	public static final SlotLoader INSTANCE = new SlotLoader();
 
-  static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "slots");
+	static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "slots");
 
-  private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
-      .create();
-  private static final int FILE_SUFFIX_LENGTH = ".json".length();
+	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
+			.create();
+	private static final int FILE_SUFFIX_LENGTH = ".json".length();
 
-  private Map<String, GroupData> slots = new HashMap<>();
+	private Map<String, GroupData> slots = new HashMap<>();
 
-  @Override
-  protected Map<String, GroupData> prepare(ResourceManager resourceManager, Profiler profiler) {
-    Map<String, GroupData> map = new HashMap<>();
-    String dataType = "slots";
+	@Override
+	protected Map<String, GroupData> prepare(ResourceManager resourceManager, Profiler profiler) {
+		Map<String, GroupData> map = new HashMap<>();
+		String dataType = "slots";
 
-    for (Identifier identifier : resourceManager
-        .findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
-      try {
-        InputStreamReader reader = new InputStreamReader(
-            resourceManager.getResource(identifier).getInputStream());
-        JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
+		for (Identifier identifier : resourceManager
+				.findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
+			try {
+				InputStreamReader reader = new InputStreamReader(
+						resourceManager.getResource(identifier).getInputStream());
+				JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
 
-        if (jsonObject != null) {
-          String path = identifier.getPath();
-          String[] parsed = path
-              .substring(dataType.length() + 1, path.length() - FILE_SUFFIX_LENGTH).split("/", 2);
-          String groupName = parsed[0];
-          String fileName = parsed[1];
-          GroupData group = map.computeIfAbsent(groupName, (k) -> new GroupData());
+				if (jsonObject != null) {
+					String path = identifier.getPath();
+					String[] parsed = path
+							.substring(dataType.length() + 1, path.length() - FILE_SUFFIX_LENGTH).split("/", 2);
+					String groupName = parsed[0];
+					String fileName = parsed[1];
+					GroupData group = map.computeIfAbsent(groupName, (k) -> new GroupData());
 
-          if (fileName.equals("group")) {
-            group.read(jsonObject);
-          } else {
-            SlotData slot = group.slots.computeIfAbsent(fileName, (k) -> new SlotData());
-            slot.read(jsonObject);
-          }
-        }
-      } catch (IOException e) {
-        e.printStackTrace();
-      }
-    }
-    return map;
-  }
+					if (fileName.equals("group")) {
+						group.read(jsonObject);
+					} else {
+						SlotData slot = group.slots.computeIfAbsent(fileName, (k) -> new SlotData());
+						slot.read(jsonObject);
+					}
+				}
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		return map;
+	}
 
-  @Override
-  protected void apply(Map<String, GroupData> loader, ResourceManager manager, Profiler profiler) {
-    this.slots = loader;
-  }
+	@Override
+	protected void apply(Map<String, GroupData> loader, ResourceManager manager, Profiler profiler) {
+		this.slots = loader;
+	}
 
-  public Map<String, GroupData> getSlots() {
-    return ImmutableMap.copyOf(this.slots);
-  }
+	public Map<String, GroupData> getSlots() {
+		return ImmutableMap.copyOf(this.slots);
+	}
 
-  @Override
-  public Identifier getFabricId() {
-    return ID;
-  }
+	@Override
+	public Identifier getFabricId() {
+		return ID;
+	}
 
-  static class GroupData {
+	static class GroupData {
 
-    private String defaultSlot = "";
-    private Map<String, SlotData> slots = new HashMap<>();
+		private String defaultSlot = "";
+		private Map<String, SlotData> slots = new HashMap<>();
 
-    void read(JsonObject jsonObject) {
-      defaultSlot = JsonHelper.getString(jsonObject, "default_slot", defaultSlot);
-    }
+		void read(JsonObject jsonObject) {
+			defaultSlot = JsonHelper.getString(jsonObject, "default_slot", defaultSlot);
+		}
 
-    String getDefaultSlot() {
-      return defaultSlot;
-    }
+		String getDefaultSlot() {
+			return defaultSlot;
+		}
 
-    SlotData getSlot(String name) {
-      return slots.get(name);
-    }
-  }
+		SlotData getSlot(String name) {
+			return slots.get(name);
+		}
+	}
 
-  static class SlotData {
+	static class SlotData {
 
-    private int order = 0;
-    private int amount = 1;
-    private int locked = 0;
-    private String icon = "";
-    private boolean transferable = false;
-    private Set<String> validators = new HashSet<>();
-    private String dropRule = DropRule.DEFAULT.toString();
+		private int order = 0;
+		private int amount = 1;
+		private int locked = 0;
+		private String icon = "";
+		private boolean transferable = false;
+		private Set<String> validators = new HashSet<>();
+		private String dropRule = DropRule.DEFAULT.toString();
 
-    SlotType create(String name) {
-      Identifier finalIcon = new Identifier(icon);
-      Set<Identifier> finalValidators = validators.stream().map(Identifier::new)
-          .collect(Collectors.toSet());
-      return new SlotType(name, order, amount, locked, finalIcon, transferable, finalValidators,
-          DropRule.valueOf(dropRule));
-    }
+		SlotType create(String name) {
+			Identifier finalIcon = new Identifier(icon);
+			Set<Identifier> finalValidators = validators.stream().map(Identifier::new)
+					.collect(Collectors.toSet());
+			return new SlotType(name, order, amount, locked, finalIcon, transferable, finalValidators,
+					DropRule.valueOf(dropRule));
+		}
 
-    void read(JsonObject jsonObject) {
-      boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);
+		void read(JsonObject jsonObject) {
+			boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);
 
-      int jsonOrder = JsonHelper.getInt(jsonObject, "order", order);
-      order = replace ? jsonOrder : Math.max(jsonOrder, order);
+			int jsonOrder = JsonHelper.getInt(jsonObject, "order", order);
+			order = replace ? jsonOrder : Math.max(jsonOrder, order);
 
-      int jsonAmount = JsonHelper.getInt(jsonObject, "amount", amount);
-      amount = replace ? jsonAmount : Math.max(jsonAmount, amount);
+			int jsonAmount = JsonHelper.getInt(jsonObject, "amount", amount);
+			amount = replace ? jsonAmount : Math.max(jsonAmount, amount);
 
-      int jsonLocked = JsonHelper.getInt(jsonObject, "locked", locked);
-      locked = replace ? jsonLocked : Math.max(jsonLocked, locked);
+			int jsonLocked = JsonHelper.getInt(jsonObject, "locked", locked);
+			locked = replace ? jsonLocked : Math.max(jsonLocked, locked);
 
-      icon = JsonHelper.getString(jsonObject, "icon", icon);
+			icon = JsonHelper.getString(jsonObject, "icon", icon);
 
-      boolean jsonTransferable = JsonHelper.getBoolean(jsonObject, "transferable", transferable);
-      transferable = replace ? jsonTransferable : (transferable || jsonTransferable);
+			boolean jsonTransferable = JsonHelper.getBoolean(jsonObject, "transferable", transferable);
+			transferable = replace ? jsonTransferable : (transferable || jsonTransferable);
 
-      String jsonDropRule = JsonHelper.getString(jsonObject, "drop_rule", dropRule);
+			String jsonDropRule = JsonHelper.getString(jsonObject, "drop_rule", dropRule);
 
-      if (DropRule.has(jsonDropRule)) {
-        dropRule = jsonDropRule;
-      }
-      JsonArray jsonValidators = JsonHelper.getArray(jsonObject, "validators", new JsonArray());
+			if (DropRule.has(jsonDropRule)) {
+				dropRule = jsonDropRule;
+			}
+			JsonArray jsonValidators = JsonHelper.getArray(jsonObject, "validators", new JsonArray());
 
-      if (jsonValidators != null) {
+			if (jsonValidators != null) {
 
-        if (replace && jsonValidators.size() > 0) {
-          validators.clear();
-        }
+				if (replace && jsonValidators.size() > 0) {
+					validators.clear();
+				}
 
-        for (JsonElement jsonValidator : jsonValidators) {
-          validators.add(jsonValidator.getAsString());
-        }
-      }
-    }
-  }
+				for (JsonElement jsonValidator : jsonValidators) {
+					validators.add(jsonValidator.getAsString());
+				}
+			}
+		}
+	}
 }

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.TrinketEnums.DropRule;
 import dev.emi.trinkets.data.SlotLoader.GroupData;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.SinglePreparationResourceReloadListener;
@@ -28,9 +30,10 @@ public class SlotLoader extends
 
   public static final SlotLoader INSTANCE = new SlotLoader();
 
+  static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "slots");
+
   private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
       .create();
-  private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "slots");
   private static final int FILE_SUFFIX_LENGTH = ".json".length();
 
   private Map<String, GroupData> slots = new HashMap<>();
@@ -91,6 +94,14 @@ public class SlotLoader extends
     void read(JsonObject jsonObject) {
       defaultSlot = JsonHelper.getString(jsonObject, "default_slot", defaultSlot);
     }
+
+    String getDefaultSlot() {
+      return defaultSlot;
+    }
+
+    SlotData getSlot(String name) {
+      return slots.get(name);
+    }
   }
 
   static class SlotData {
@@ -102,6 +113,14 @@ public class SlotLoader extends
     private boolean transferable = false;
     private Set<String> validators = new HashSet<>();
     private String dropRule = DropRule.DEFAULT.toString();
+
+    SlotType create(String name) {
+      Identifier finalIcon = new Identifier(icon);
+      Set<Identifier> finalValidators = validators.stream().map(Identifier::new)
+          .collect(Collectors.toSet());
+      return new SlotType(name, order, amount, locked, finalIcon, transferable, finalValidators,
+          DropRule.valueOf(dropRule));
+    }
 
     void read(JsonObject jsonObject) {
       boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -1,0 +1,142 @@
+package dev.emi.trinkets.data;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.TrinketEnums.DropRule;
+import dev.emi.trinkets.data.SlotLoader.GroupData;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.resource.SinglePreparationResourceReloadListener;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+import net.minecraft.util.profiler.Profiler;
+
+public class SlotLoader extends
+    SinglePreparationResourceReloadListener<Map<String, GroupData>> implements
+    IdentifiableResourceReloadListener {
+
+  public static final SlotLoader INSTANCE = new SlotLoader();
+
+  private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
+      .create();
+  private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "slots");
+  private static final int FILE_SUFFIX_LENGTH = ".json".length();
+
+  private Map<String, GroupData> slots = new HashMap<>();
+
+  @Override
+  protected Map<String, GroupData> prepare(ResourceManager resourceManager, Profiler profiler) {
+    Map<String, GroupData> map = new HashMap<>();
+    String dataType = "slots";
+
+    for (Identifier identifier : resourceManager
+        .findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
+      try {
+        InputStreamReader reader = new InputStreamReader(
+            resourceManager.getResource(identifier).getInputStream());
+        JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
+
+        if (jsonObject != null) {
+          String path = identifier.getPath();
+          String[] parsed = path
+              .substring(dataType.length() + 1, path.length() - FILE_SUFFIX_LENGTH).split("/", 2);
+          String groupName = parsed[0];
+          String fileName = parsed[1];
+          GroupData group = map.computeIfAbsent(groupName, (k) -> new GroupData());
+
+          if (fileName.equals("group")) {
+            group.read(jsonObject);
+          } else {
+            SlotData slot = group.slots.computeIfAbsent(fileName, (k) -> new SlotData());
+            slot.read(jsonObject);
+          }
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    return map;
+  }
+
+  @Override
+  protected void apply(Map<String, GroupData> loader, ResourceManager manager, Profiler profiler) {
+    this.slots = loader;
+  }
+
+  public Map<String, GroupData> getSlots() {
+    return ImmutableMap.copyOf(this.slots);
+  }
+
+  @Override
+  public Identifier getFabricId() {
+    return ID;
+  }
+
+  static class GroupData {
+
+    private String defaultSlot = "";
+    private Map<String, SlotData> slots = new HashMap<>();
+
+    void read(JsonObject jsonObject) {
+      defaultSlot = JsonHelper.getString(jsonObject, "default_slot", defaultSlot);
+    }
+  }
+
+  static class SlotData {
+
+    private int order = 0;
+    private int amount = 1;
+    private int locked = 0;
+    private String icon = "";
+    private boolean transferable = false;
+    private Set<String> validators = new HashSet<>();
+    private String dropRule = DropRule.DEFAULT.toString();
+
+    void read(JsonObject jsonObject) {
+      boolean replace = JsonHelper.getBoolean(jsonObject, "replace", false);
+
+      int jsonOrder = JsonHelper.getInt(jsonObject, "order", order);
+      order = replace ? jsonOrder : Math.max(jsonOrder, order);
+
+      int jsonAmount = JsonHelper.getInt(jsonObject, "amount", amount);
+      amount = replace ? jsonAmount : Math.max(jsonAmount, amount);
+
+      int jsonLocked = JsonHelper.getInt(jsonObject, "locked", locked);
+      locked = replace ? jsonLocked : Math.max(jsonLocked, locked);
+
+      icon = JsonHelper.getString(jsonObject, "icon", icon);
+
+      boolean jsonTransferable = JsonHelper.getBoolean(jsonObject, "transferable", transferable);
+      transferable = replace ? jsonTransferable : (transferable || jsonTransferable);
+
+      String jsonDropRule = JsonHelper.getString(jsonObject, "drop_rule", dropRule);
+
+      if (DropRule.has(jsonDropRule)) {
+        dropRule = jsonDropRule;
+      }
+      JsonArray jsonValidators = JsonHelper.getArray(jsonObject, "validators", new JsonArray());
+
+      if (jsonValidators != null) {
+
+        if (replace && jsonValidators.size() > 0) {
+          validators.clear();
+        }
+
+        for (JsonElement jsonValidator : jsonValidators) {
+          validators.add(jsonValidator.getAsString());
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/data/trinkets/entities/default.json
+++ b/src/main/resources/data/trinkets/entities/default.json
@@ -1,7 +1,0 @@
-{
-  "entities": ["player"],
-  "slots": [
-    "hand/ring",
-    "offhand/ring"
-  ]
-}

--- a/src/main/resources/data/trinkets/entities/default.json
+++ b/src/main/resources/data/trinkets/entities/default.json
@@ -1,0 +1,7 @@
+{
+  "entities": ["player"],
+  "slots": [
+    "hand/ring",
+    "offhand/ring"
+  ]
+}

--- a/src/main/resources/data/trinkets/slots/chest/backpack.json
+++ b/src/main/resources/data/trinkets/slots/chest/backpack.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_backpack"
+}

--- a/src/main/resources/data/trinkets/slots/chest/cape.json
+++ b/src/main/resources/data/trinkets/slots/chest/cape.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_cape"
+}

--- a/src/main/resources/data/trinkets/slots/chest/necklace.json
+++ b/src/main/resources/data/trinkets/slots/chest/necklace.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_necklace"
+}

--- a/src/main/resources/data/trinkets/slots/feet/aglet.json
+++ b/src/main/resources/data/trinkets/slots/feet/aglet.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_aglet"
+}

--- a/src/main/resources/data/trinkets/slots/hand/gloves.json
+++ b/src/main/resources/data/trinkets/slots/hand/gloves.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_gloves"
+}

--- a/src/main/resources/data/trinkets/slots/hand/ring.json
+++ b/src/main/resources/data/trinkets/slots/hand/ring.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_ring"
+}

--- a/src/main/resources/data/trinkets/slots/head/mask.json
+++ b/src/main/resources/data/trinkets/slots/head/mask.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_mask"
+}

--- a/src/main/resources/data/trinkets/slots/legs/belt.json
+++ b/src/main/resources/data/trinkets/slots/legs/belt.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_belt"
+}

--- a/src/main/resources/data/trinkets/slots/offhand/ring.json
+++ b/src/main/resources/data/trinkets/slots/offhand/ring.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:item/empty_trinket_slot_ring"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -11,6 +11,12 @@
 			"contact": {
 				"github": "https://github.com/emilyploszaj"
 			}
+		},
+		{
+			"name": "C4",
+			"contact": {
+				"github": "https://github.com/TheIllusiveC4"
+			}
 		}
 	],
 	"contact": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,6 +34,14 @@
 		],
 		"client": [
 			"dev.emi.trinkets.TrinketsClient"
+		],
+		"cardinal-components-entity": [
+			"dev.emi.trinkets.TrinketsMain"
+		]
+	},
+	"custom": {
+		"cardinal-components": [
+			"trinkets:trinkets"
 		]
 	},
 	"mixins": [


### PR DESCRIPTION
- Created `SlotLoader` and `EntitySlotLoader` to load slots and entity slot distribution respectively
- Registered data listeners in `TrinketsMain`
- Created `TrinketEnums` to hold various enums, currently has `DropRule` for denoting drop behavior to be fully implemented at a later time
- Created `SlotGroup` and `SlotType` for slot groups and slots respectively
- Created `TrinketSlots` as the primary way to access entity slots
- Added data files for Trinkets's list of suggested slots
- Added myself to the authors list in `fabric.mod.json`
- Added entrypoints for CCA static component registration (needed this in order to fully test this PR)

The data loading is still rudimentary, notably lacking proper error handling, but it should provide enough functionality to move forward for the moment. As long as slots are accessed primarily through `TrinketSlots`, the implementation details can change later on without affecting the rest of the code.

One benefit of this system is that we can define suggested slots and they will exist, but they won't do anything until developers or users define an entity to receive those slots. I have defined all of the slots that Trinkets has historically suggested and given them their default icons.

Here's a datapack that we can use to add all of those slots to the player, for testing purposes, so that we never have to attach any slots to the player natively.

[debug.zip](https://github.com/emilyploszaj/trinkets/files/5178615/debug.zip)
