### PR TITLE
Implement a lot of missing bits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,11 @@ dependencies {
 	// You may need to force-disable transitiveness on them.
 	
 	// Base
-	modCompile "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:2.5.3"
-	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:2.5.3"
+	modCompile "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:2.5.4"
+	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:2.5.4"
 	// Entity
-	modCompile "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:2.5.3"
-	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:2.5.3"
+	modCompile "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:2.5.4"
+	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:2.5.4"
 
 	//modRuntime ("com.github.SuperCoder7979:databreaker:0.2.5") {
 	//	exclude module : "fabric-loader"

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,16 +1,21 @@
 package dev.emi.trinkets;
 
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
+import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.emi.trinkets.data.SlotLoader;
 import dev.onyxstudios.cca.api.v3.component.ComponentKey;
 import dev.onyxstudios.cca.api.v3.component.ComponentRegistryV3;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
+import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
@@ -30,10 +35,22 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 				.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
+		TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket(){
+			
+			@Override
+			public void tick(ItemStack stack, SlotReference slot, LivingEntity entity) {
+				System.out.println(slot.slot.getName());
+			}
+		});
 	}
 
-  @Override
+  	@Override
 	public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
-		registry.registerFor(LivingEntity.class, TRINKETS, LivingEntityTrinketComponent::new);
+		registry.registerForPlayers(TRINKETS, entity -> {
+			return new LivingEntityTrinketComponent(entity);
+		}, RespawnCopyStrategy.ALWAYS_COPY);
+		registry.registerFor(LivingEntity.class, TRINKETS, entity -> {
+			return new LivingEntityTrinketComponent(entity);
+		});
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,9 +1,7 @@
 package dev.emi.trinkets;
 
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
-import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketComponent;
-import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.emi.trinkets.data.SlotLoader;
 import dev.onyxstudios.cca.api.v3.component.ComponentKey;
@@ -14,8 +12,6 @@ import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
@@ -35,13 +31,13 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 				.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
-		TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket(){
+		/*TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket(){
 			
 			@Override
 			public void tick(ItemStack stack, SlotReference slot, LivingEntity entity) {
 				System.out.println(slot.slot.getName());
 			}
-		});
+		});*/
 	}
 
   	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -1,24 +1,81 @@
 package dev.emi.trinkets.api;
 
+import java.util.Map;
+import java.util.Set;
+
+import dev.emi.trinkets.TrinketsMain;
 import dev.onyxstudios.cca.api.v3.component.AutoSyncedComponent;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 
 public class LivingEntityTrinketComponent implements TrinketComponent, AutoSyncedComponent {
 
+	public TrinketInventory inventory;
 	public LivingEntity entity;
 
 	public LivingEntityTrinketComponent(LivingEntity entity) {
 		this.entity = entity;
+		this.inventory = new TrinketInventory(this);
 	}
 
 	@Override
 	public void readFromNbt(CompoundTag tag) {
-
+		Set<String> keys = tag.getKeys();
+		for (Map.Entry<SlotType, Integer> entry : inventory.slotMap.entrySet()) {
+			String name = entry.getKey().getGroup() + ":" + entry.getKey().getName();
+			if (tag.contains(name, 9)) { // ListTag
+				ListTag list = tag.getList(name, 10);
+				int offset = entry.getValue();
+				for (int i = 0; i < list.size(); i++) {
+					CompoundTag c = list.getCompound(i);
+					ItemStack stack = ItemStack.fromTag(c);
+					if (i >= entry.getKey().getAmount()) {
+						if (!stack.isEmpty()) {
+							// If amount is lowered between loads of the entity drop excess
+							TrinketsMain.LOGGER.info("[trinkets] Found item in slot that doesn't exist! Dropping on ground.");
+							entity.dropStack(stack);
+						}
+					} else {
+						inventory.setStack(offset + i, stack);
+					}
+				}
+			}
+			keys.remove(name);
+		}
+		for (String key : keys) {
+			if (tag.getType(key) == 9) { // ListTag
+				ListTag list = tag.getList(key, 10);
+				for (int i = 0; i < list.size(); i++) {
+					CompoundTag c = list.getCompound(i);
+					ItemStack stack = ItemStack.fromTag(c);
+					if (!stack.isEmpty()) {
+						// If slot is removed between loads of the entity drop items
+						TrinketsMain.LOGGER.info("[trinkets] Found item in slot that doesn't exist! Dropping on ground.");
+						entity.dropStack(stack);
+					}
+				}
+			}
+		}
 	}
 
 	@Override
 	public void writeToNbt(CompoundTag tag) {
+		for (Map.Entry<SlotType, Integer> entry : inventory.slotMap.entrySet()) {
+			ListTag list = new ListTag();
+			int offset = entry.getValue();
+			for (int i = 0; i < entry.getKey().getAmount(); i++) {
+				CompoundTag c = new CompoundTag();
+				inventory.getStack(offset + i).toTag(c);
+				list.add(c);
+			}
+			tag.put(entry.getKey().getGroup() + ":" + entry.getKey().getName(), list);
+		}
+	}
 
+	@Override
+	public TrinketInventory getInventory() {
+		return inventory;
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotType.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotType.java
@@ -6,6 +6,7 @@ import net.minecraft.util.Identifier;
 
 public class SlotType {
 
+	private final String group;
 	private final String name;
 	private final int order;
 	private final int amount;
@@ -15,8 +16,9 @@ public class SlotType {
 	private final Set<Identifier> validators;
 	private final DropRule dropRule;
 
-	public SlotType(String name, int order, int amount, int locked, Identifier icon,
+	public SlotType(String group, String name, int order, int amount, int locked, Identifier icon,
 			boolean transferable, Set<Identifier> validators, DropRule dropRule) {
+		this.group = group;
 		this.name = name;
 		this.order = order;
 		this.amount = amount;
@@ -25,6 +27,10 @@ public class SlotType {
 		this.transferable = transferable;
 		this.validators = validators;
 		this.dropRule = dropRule;
+	}
+
+	public String getGroup() {
+		return group;
 	}
 
 	public String getName() {

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -18,7 +18,7 @@ public interface Trinket {
 	/**
 	 * Called every tick on the client and server side
 	 */
-	public default void tick(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default void tick(ItemStack stack, SlotReference slot, LivingEntity entity) {
 	}
 
 	/**
@@ -26,7 +26,7 @@ public interface Trinket {
 	 *
 	 * @param stack The stack being equipped
 	 */
-	public default void onEquip(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default void onEquip(ItemStack stack, SlotReference slot, LivingEntity entity) {
 	}
 
 	/**
@@ -34,14 +34,14 @@ public interface Trinket {
 	 *
 	 * @param stack The stack being unequipped
 	 */
-	public default void onUnequip(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default void onUnequip(ItemStack stack, SlotReference slot, LivingEntity entity) {
 	}
 
-	public default boolean canEquip(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default boolean canEquip(ItemStack stack, SlotReference slot, LivingEntity entity) {
 		return true;
 	}
 
-	public default boolean canUnequip(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default boolean canUnequip(ItemStack stack, SlotReference slot, LivingEntity entity) {
 		return !EnchantmentHelper.hasBindingCurse(stack);
 	}
 
@@ -50,7 +50,7 @@ public interface Trinket {
 	 * remain pure
 	 */
 	public default Multimap<EntityAttribute, EntityAttributeModifier> getModifiers(ItemStack stack,
-			TrinketSlot slot, LivingEntity entity) {
+			SlotReference slot, LivingEntity entity) {
 		Multimap<EntityAttribute, EntityAttributeModifier> map = HashMultimap.create();
 		if (stack.hasTag() && stack.getTag().contains("TrinketAttributeModifiers", 9)) {
 			ListTag list = stack.getTag().getList("TrinketAttributeModifiers", 10);
@@ -75,13 +75,21 @@ public interface Trinket {
 		return map;
 	}
 
-	public default void onBreak(ItemStack stack, TrinketSlot slot, LivingEntity entity) {
+	public default void onBreak(ItemStack stack, SlotReference slot, LivingEntity entity) {
 		// TODO
 	}
 
-	// TODO getDropRule
+	public default TrinketEnums.DropRule getDropRule(ItemStack stack, SlotReference slot, LivingEntity entity) {
+		return TrinketEnums.DropRule.DEFAULT;
+	}
 
-	class TrinketSlot {
-		// Temporary dummy type 
+	public static class SlotReference {
+		public SlotType slot;
+		public int index; 
+
+		public SlotReference(SlotType slot, int index) {
+			this.slot = slot;
+			this.index = index;
+		}
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
@@ -4,4 +4,5 @@ import dev.onyxstudios.cca.api.v3.component.ComponentV3;
 
 public interface TrinketComponent extends ComponentV3 {
 
+	public TrinketInventory getInventory();
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -1,0 +1,95 @@
+package dev.emi.trinkets.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.inventory.Inventories;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Pair;
+import net.minecraft.util.collection.DefaultedList;
+
+public class TrinketInventory implements Inventory {
+	public LivingEntityTrinketComponent component;
+	public DefaultedList<ItemStack> stacks;
+	// This is a really weird solution to the problem of quickly getting slots, I plan on changing it to something more reasonable
+	public Map<SlotType, Integer> slotMap = new HashMap<SlotType, Integer>();
+	public Map<Integer, Pair<SlotType, Integer>> posMap = new HashMap<Integer, Pair<SlotType, Integer>>();
+	public int size;
+
+	public TrinketInventory(LivingEntityTrinketComponent comp) {
+		this.component = comp;
+		Map<String, SlotGroup> groups;
+		if (comp.entity.getType() == EntityType.PLAYER) { // TODO potentially change this logic if getEntitySlots starts to supports players
+			groups = TrinketSlots.getPlayerSlots();
+		} else {
+			groups = TrinketSlots.getEntitySlots(comp.entity.getType());
+		}
+		int i = 0;
+		for (Map.Entry<String, SlotGroup> group : groups.entrySet()) {
+			Map<String, SlotType> slots = group.getValue().getSlots();
+			for (Map.Entry<String, SlotType> slot : slots.entrySet()) {
+				slotMap.put(slot.getValue(), i);
+				for (int j = 0; j < slot.getValue().getAmount(); j++) {
+					posMap.put(i + j, new Pair<SlotType, Integer>(slot.getValue(), j));
+				}
+				i += slot.getValue().getAmount();
+			}
+		}
+		size = i;
+		stacks = DefaultedList.ofSize(size, ItemStack.EMPTY);
+	}
+
+	@Override
+	public void clear() {
+		for (int i = 0; i < size; i++) {
+			stacks.set(i, ItemStack.EMPTY);
+		}
+	}
+
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		for (int i = 0; i < size; i++) {
+			if (!stacks.get(i).isEmpty()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public ItemStack getStack(int slot) {
+		return stacks.get(slot);
+	}
+	
+	@Override
+	public ItemStack removeStack(int slot, int amount) {
+		return Inventories.splitStack(stacks, slot, amount);
+	}
+	
+	@Override
+	public ItemStack removeStack(int slot) {
+		return Inventories.removeStack(stacks, slot);
+	}
+
+	@Override
+	public void setStack(int slot, ItemStack stack) {
+		stacks.set(slot, stack);
+	}
+
+	@Override
+	public void markDirty() {
+	}
+
+	@Override
+	public boolean canPlayerUse(PlayerEntity player) {
+		return true;
+	}
+}

--- a/src/main/java/dev/emi/trinkets/api/TrinketItem.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketItem.java
@@ -1,0 +1,11 @@
+package dev.emi.trinkets.api;
+
+import net.minecraft.item.Item;
+
+public class TrinketItem extends Item implements Trinket {
+	
+	public TrinketItem(Item.Settings settings) {
+		super(settings);
+		TrinketsApi.registerTrinket(this, this);
+	}
+}

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,0 +1,22 @@
+package dev.emi.trinkets.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraft.item.Item;
+
+public class TrinketsApi {
+	private static final Map<Item, Trinket> TRINKETS = new HashMap<Item, Trinket>();
+	
+	public static void registerTrinket(Item item, Trinket trinket) {
+		TRINKETS.put(item, trinket);
+	}
+
+	public static boolean hasTrinket(Item item) {
+		return TRINKETS.containsKey(item);
+	}
+
+	public static Trinket getTrinket(Item item) {
+		return TRINKETS.get(item);
+	}
+}

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -110,7 +110,7 @@ public class EntitySlotLoader extends
 						SlotData slotData = group.getSlot(slotName);
 
 						if (slotData != null) {
-							builder.addSlot(slotName, slotData.create(slotName));
+							builder.addSlot(slotName, slotData.create(groupName, slotName));
 						}
 					});
 				}
@@ -137,7 +137,10 @@ public class EntitySlotLoader extends
 	}
 
 	public Map<String, SlotGroup> getEntitySlots(EntityType<?> entityType) {
-		return ImmutableMap.copyOf(this.entitySlots.get(entityType));
+		if (this.entitySlots.containsKey(entityType)) {
+			return ImmutableMap.copyOf(this.entitySlots.get(entityType));
+		}
+		return ImmutableMap.of();
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -114,11 +114,11 @@ public class SlotLoader extends
 		private Set<String> validators = new HashSet<>();
 		private String dropRule = DropRule.DEFAULT.toString();
 
-		SlotType create(String name) {
+		SlotType create(String group, String name) {
 			Identifier finalIcon = new Identifier(icon);
 			Set<Identifier> finalValidators = validators.stream().map(Identifier::new)
 					.collect(Collectors.toSet());
-			return new SlotType(name, order, amount, locked, finalIcon, transferable, finalValidators,
+			return new SlotType(group, name, order, amount, locked, finalIcon, transferable, finalValidators,
 					DropRule.valueOf(dropRule));
 		}
 

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -1,0 +1,78 @@
+package dev.emi.trinkets.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.Trinket;
+import dev.emi.trinkets.api.TrinketEnums;
+import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketsApi;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Pair;
+import net.minecraft.world.GameRules;
+import net.minecraft.world.World;
+
+/**
+ * Trinket dropping on death
+ * 
+ * @author Emi
+ */
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin extends Entity {
+
+	protected LivingEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
+		super(entityType, world);
+	}
+	
+	@Inject(at = @At("TAIL"), method = "dropInventory")
+	public void dropInventory(CallbackInfo info) {
+		boolean keepInv = this.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY);
+		LivingEntity entity = (LivingEntity) (Object) this;
+		TrinketInventory inv = TrinketsMain.TRINKETS.get(entity).getInventory();
+		for (int i = 0; i < inv.size(); i++) {
+			ItemStack stack = inv.getStack(i);
+			if (stack.isEmpty()) {
+				continue;
+			}
+
+			TrinketEnums.DropRule dropRule = TrinketEnums.DropRule.DEFAULT;
+			Pair<SlotType, Integer> p = inv.posMap.get(i);
+			if (TrinketsApi.hasTrinket(stack.getItem())) {
+				dropRule = TrinketsApi.getTrinket(stack.getItem()).getDropRule(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), entity);
+			}
+			if (dropRule == TrinketEnums.DropRule.DEFAULT) {
+				dropRule = p.getLeft().getDropRule();
+			}
+			if (dropRule == TrinketEnums.DropRule.DEFAULT) {
+				if (keepInv && this.getType() == EntityType.PLAYER) {
+					dropRule = TrinketEnums.DropRule.ALWAYS_KEEP;
+				} else {
+					if (EnchantmentHelper.hasVanishingCurse(stack)) {
+						dropRule = TrinketEnums.DropRule.DESTROY;
+					} else {
+						dropRule = TrinketEnums.DropRule.ALWAYS_DROP;
+					}
+				}
+			}
+
+			switch (dropRule) {
+				case ALWAYS_DROP:
+					dropStack(stack);
+					// Fallthrough
+				case DESTROY:
+					inv.setStack(i, ItemStack.EMPTY);
+					break;
+				default:
+					break;
+			}
+		}
+	}
+}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerInventoryMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerInventoryMixin.java
@@ -1,0 +1,41 @@
+package dev.emi.trinkets.mixin;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.Trinket;
+import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketsApi;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Pair;
+
+/**
+ * Ticks trinkets
+ * 
+ * @author Emi
+ */
+@Mixin(PlayerInventory.class)
+public class PlayerInventoryMixin {
+	@Shadow @Final
+	public PlayerEntity player;
+	
+	@Inject(at = @At("TAIL"), method = "updateItems")
+	public void updateItems(CallbackInfo info) {
+		TrinketInventory inv = TrinketsMain.TRINKETS.get(player).getInventory();
+		for (int i = 0; i < inv.size(); i++) {
+			ItemStack stack = inv.getStack(i);
+			if (TrinketsApi.hasTrinket(stack.getItem())) {
+				Pair<SlotType, Integer> p = inv.posMap.get(i);
+				TrinketsApi.getTrinket(stack.getItem()).tick(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), player);
+			}
+		}
+	}
+}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -1,0 +1,38 @@
+package dev.emi.trinkets.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.TrinketInventory;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.PlayerScreenHandler;
+import net.minecraft.screen.ScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+import net.minecraft.screen.slot.Slot;
+
+/**
+ * Adds trinket slots to the player's screen handler
+ * 
+ * @author Emi 
+ */
+@Mixin(PlayerScreenHandler.class)
+public abstract class PlayerScreenHandlerMixin extends ScreenHandler {
+	public int trinketSlotStart;
+
+	protected PlayerScreenHandlerMixin(ScreenHandlerType<?> type, int syncId) {
+		super(type, syncId);
+	}
+
+	@Inject(at = @At("RETURN"), method = "<init>")
+	public void init(PlayerInventory playerInv, boolean onServer, PlayerEntity owner, CallbackInfo info) {
+		trinketSlotStart = slots.size();
+		TrinketInventory inv = TrinketsMain.TRINKETS.get(owner).getInventory();
+		for (int i = 0; i < inv.size(); i++) {
+			this.addSlot(new Slot(inv, i, i * 16, 0)); // TODO actually do something reasonable with the slots
+		}
+	}
+}

--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -3,6 +3,9 @@
 	"package": "dev.emi.trinkets.mixin",
 	"compatibilityLevel": "JAVA_8",
 	"mixins": [
+		"PlayerScreenHandlerMixin",
+		"PlayerInventoryMixin",
+		"LivingEntityMixin"
 	],
 	"client": [
 	],


### PR DESCRIPTION
* Update Cardinal Components
* Serialize `LivingEntityTrinketComponent`s
* Added `TrinketInventory`
* `TrinketComponent`s now have a method to get their `TrinketInventory`
* Changed type passed to `Trinket`s to a `Trinket.SlotReference` which includes slot type and index of
* Added `TrinketItem`, an `Item` that automatically registers itself as a trinket, for easy hard deps
* Added `TrinketsAPI` with methods to register and get `Trinket`s for items
* Fully implemented ticking and dropping for trinkets
* Temporarily put trinket slots at the head of the inventory, for simple debugging until a proper GUI is implemented