### PR TITLE
Small refactors and trinket renderer registry

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketFeatureRenderer.java
+++ b/src/main/java/dev/emi/trinkets/TrinketFeatureRenderer.java
@@ -1,0 +1,44 @@
+package dev.emi.trinkets;
+
+import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.Trinket;
+import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.client.TrinketRendererRegistry;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.feature.FeatureRenderer;
+import net.minecraft.client.render.entity.feature.FeatureRendererContext;
+import net.minecraft.client.render.entity.model.PlayerEntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Pair;
+
+public class TrinketFeatureRenderer extends FeatureRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
+
+	private FeatureRendererContext<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> context;
+
+	public TrinketFeatureRenderer(FeatureRendererContext<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> context) {
+		super(context);
+		this.context = context;
+	}
+
+	@Override
+	public void render(MatrixStack matrixStack, VertexConsumerProvider vertexConsumer, int light, AbstractClientPlayerEntity player, float a, float b, float c, float d,
+			float headYaw, float headPitch) {
+		TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> {
+			TrinketInventory inv = trinkets.getInventory();
+
+			for (int i = 0; i < inv.size(); i++) {
+				ItemStack stack = inv.getStack(i);
+				Pair<SlotType, Integer> p = inv.posMap.get(i);
+				TrinketRendererRegistry.getRenderer(stack.getItem()).ifPresent(renderer -> {
+					matrixStack.push();
+					renderer.render(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), matrixStack, vertexConsumer, light, context.getModel(), player,
+							headYaw, headPitch);
+					matrixStack.pop();
+				});
+			}
+		});
+	}
+}

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,11 +1,9 @@
 package dev.emi.trinkets;
 
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
-import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.emi.trinkets.data.SlotLoader;
-import dev.onyxstudios.cca.api.v3.component.ComponentKey;
-import dev.onyxstudios.cca.api.v3.component.ComponentRegistryV3;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
@@ -13,7 +11,6 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.resource.ResourceType;
-import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,13 +19,9 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 	public static final String MOD_ID = "trinkets";
 	public static final Logger LOGGER = LogManager.getLogger();
 
-	public static final ComponentKey<TrinketComponent> TRINKETS = ComponentRegistryV3.INSTANCE
-			.getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
-
 	@Override
 	public void onInitialize() {
-		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper
-				.get(ResourceType.SERVER_DATA);
+		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
 		/*TrinketsApi.registerTrinket(Items.DIAMOND, new Trinket(){
@@ -40,12 +33,12 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 		});*/
 	}
 
-  	@Override
+	@Override
 	public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
-		registry.registerForPlayers(TRINKETS, entity -> {
+		registry.registerForPlayers(TrinketsApi.TRINKET_COMPONENT, entity -> {
 			return new LivingEntityTrinketComponent(entity);
 		}, RespawnCopyStrategy.ALWAYS_COPY);
-		registry.registerFor(LivingEntity.class, TRINKETS, entity -> {
+		registry.registerFor(LivingEntity.class, TrinketsApi.TRINKET_COMPONENT, entity -> {
 			return new LivingEntityTrinketComponent(entity);
 		});
 	}

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,12 +1,20 @@
 package dev.emi.trinkets.api;
 
 import dev.emi.trinkets.data.EntitySlotLoader;
+import dev.onyxstudios.cca.api.v3.component.ComponentKey;
+import dev.onyxstudios.cca.api.v3.component.ComponentRegistryV3;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.Item;
+import net.minecraft.util.Identifier;
 
 public class TrinketsApi {
+
+	public static final ComponentKey<TrinketComponent> TRINKET_COMPONENT = ComponentRegistryV3.INSTANCE
+			.getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
 
 	private static final Map<Item, Trinket> TRINKETS = new HashMap<Item, Trinket>();
 
@@ -14,12 +22,12 @@ public class TrinketsApi {
 		TRINKETS.put(item, trinket);
 	}
 
-	public static boolean hasTrinket(Item item) {
-		return TRINKETS.containsKey(item);
+	public static Optional<Trinket> getTrinket(Item item) {
+		return Optional.ofNullable(TRINKETS.get(item));
 	}
 
-	public static Trinket getTrinket(Item item) {
-		return TRINKETS.get(item);
+	public static Optional<TrinketComponent> getTrinketComponent(LivingEntity livingEntity) {
+		return TRINKET_COMPONENT.maybeGet(livingEntity);
 	}
 
 	public static Map<String, SlotGroup> getPlayerSlots() {

--- a/src/main/java/dev/emi/trinkets/api/client/TrinketRenderer.java
+++ b/src/main/java/dev/emi/trinkets/api/client/TrinketRenderer.java
@@ -13,6 +13,7 @@ public interface TrinketRenderer {
 	void render(ItemStack stack, Trinket.SlotReference slot, MatrixStack matrixStack, VertexConsumerProvider vertexConsumer, int light,
 			PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float headYaw, float headPitch);
 
+	// todo: Review these translation methods before release
 	/**
 	 * Translates the rendering context to the center of the player's face
 	 */

--- a/src/main/java/dev/emi/trinkets/api/client/TrinketRenderer.java
+++ b/src/main/java/dev/emi/trinkets/api/client/TrinketRenderer.java
@@ -1,0 +1,111 @@
+package dev.emi.trinkets.api.client;
+
+import dev.emi.trinkets.api.Trinket;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.model.PlayerEntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.util.math.Vector3f;
+import net.minecraft.item.ItemStack;
+
+public interface TrinketRenderer {
+
+	void render(ItemStack stack, Trinket.SlotReference slot, MatrixStack matrixStack, VertexConsumerProvider vertexConsumer, int light,
+			PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float headYaw, float headPitch);
+
+	/**
+	 * Translates the rendering context to the center of the player's face
+	 */
+	static void translateToFace(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player, float headYaw,
+			float headPitch) {
+
+		if (player.isInSwimmingPose() || player.isFallFlying()) {
+			matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.head.roll));
+			matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
+			matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(-45.0F));
+		} else {
+
+			if (player.isInSneakingPose() && !model.riding) {
+				matrixStack.translate(0.0F, 0.25F, 0.0F);
+			}
+			matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(headYaw));
+			matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(headPitch));
+		}
+		matrixStack.translate(0.0F, -0.25F, -0.3F);
+	}
+
+	/**
+	 * Translates the rendering context to the center of the player's chest/torso segment
+	 */
+	static void translateToChest(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+
+		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
+			matrixStack.translate(0.0F, 0.2F, 0.0F);
+			matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.torso.pitch * 57.5F));
+		}
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * 57.5F));
+		matrixStack.translate(0.0F, 0.4F, -0.16F);
+	}
+
+	/**
+	 * Translates the rendering context to the center of the bottom of the player's right arm
+	 */
+	static void translateToRightArm(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+
+		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
+			matrixStack.translate(0.0F, 0.2F, 0.0F);
+		}
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * 57.5F));
+		matrixStack.translate(-0.3125F, 0.15625F, 0.0F);
+		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.rightArm.roll * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.rightArm.yaw * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.rightArm.pitch * 57.5F));
+		matrixStack.translate(-0.0625F, 0.625F, 0.0F);
+	}
+
+	/**
+	 * Translates the rendering context to the center of the bottom of the player's left arm
+	 */
+	static void translateToLeftArm(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+
+		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
+			matrixStack.translate(0.0F, 0.2F, 0.0F);
+		}
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.torso.yaw * 57.5F));
+		matrixStack.translate(0.3125F, 0.15625F, 0.0F);
+		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.leftArm.roll * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.leftArm.yaw * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.leftArm.pitch * 57.5F));
+		matrixStack.translate(0.0625F, 0.625F, 0.0F);
+	}
+
+	/**
+	 * Translates the rendering context to the center of the bottom of the player's right leg
+	 */
+	static void translateToRightLeg(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+
+		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
+			matrixStack.translate(0.0F, 0.0F, 0.25F);
+		}
+		matrixStack.translate(-0.125F, 0.75F, 0.0F);
+		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.rightLeg.roll * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.rightLeg.yaw * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.rightLeg.pitch * 57.5F));
+		matrixStack.translate(0.0F, 0.75F, 0.0F);
+	}
+
+	/**
+	 * Translates the rendering context to the center of the bottom of the player's left leg
+	 */
+	static void translateToLeftLeg(MatrixStack matrixStack, PlayerEntityModel<AbstractClientPlayerEntity> model, AbstractClientPlayerEntity player) {
+
+		if (player.isInSneakingPose() && !model.riding && !player.isSwimming()) {
+			matrixStack.translate(0.0F, 0.0F, 0.25F);
+		}
+		matrixStack.translate(0.125F, 0.75F, 0.0F);
+		matrixStack.multiply(Vector3f.POSITIVE_Z.getDegreesQuaternion(model.leftLeg.roll * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(model.leftLeg.yaw * 57.5F));
+		matrixStack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(model.leftLeg.pitch * 57.5F));
+		matrixStack.translate(0.0F, 0.75F, 0.0F);
+	}
+}

--- a/src/main/java/dev/emi/trinkets/api/client/TrinketRendererRegistry.java
+++ b/src/main/java/dev/emi/trinkets/api/client/TrinketRendererRegistry.java
@@ -1,0 +1,19 @@
+package dev.emi.trinkets.api.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import net.minecraft.item.Item;
+
+public class TrinketRendererRegistry {
+
+	private static final Map<Item, TrinketRenderer> RENDERERS = new HashMap<>();
+
+	public static void registerRenderer(Item item, TrinketRenderer trinketRenderer) {
+		RENDERERS.put(item, trinketRenderer);
+	}
+
+	public static Optional<TrinketRenderer> getRenderer(Item item) {
+		return Optional.ofNullable(RENDERERS.get(item));
+	}
+}

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -28,29 +28,23 @@ import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.Registry;
 
-public class EntitySlotLoader extends
-		SinglePreparationResourceReloadListener<Map<String, Map<String, Set<String>>>> implements
-		IdentifiableResourceReloadListener {
+public class EntitySlotLoader extends SinglePreparationResourceReloadListener<Map<String, Map<String, Set<String>>>> implements IdentifiableResourceReloadListener {
 
 	public static final EntitySlotLoader INSTANCE = new EntitySlotLoader();
 
-	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
-			.create();
+	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping().create();
 	private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "entities");
 
 	private Map<EntityType<?>, Map<String, SlotGroup>> slots = new HashMap<>();
 
 	@Override
-	protected Map<String, Map<String, Set<String>>> prepare(ResourceManager resourceManager,
-			Profiler profiler) {
+	protected Map<String, Map<String, Set<String>>> prepare(ResourceManager resourceManager, Profiler profiler) {
 		Map<String, Map<String, Set<String>>> map = new HashMap<>();
 		String dataType = "entities";
 
-		for (Identifier identifier : resourceManager
-				.findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
+		for (Identifier identifier : resourceManager.findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
 			try {
-				InputStreamReader reader = new InputStreamReader(
-						resourceManager.getResource(identifier).getInputStream());
+				InputStreamReader reader = new InputStreamReader(resourceManager.getResource(identifier).getInputStream());
 				JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
 
 				if (jsonObject != null) {
@@ -87,13 +81,12 @@ public class EntitySlotLoader extends
 								if (replace) {
 									slots.clear();
 								}
-								groups.forEach((groupName, slotNames) -> slots
-										.computeIfAbsent(groupName, (k) -> new HashSet<>()).addAll(slotNames));
+								groups.forEach((groupName, slotNames) -> slots.computeIfAbsent(groupName, (k) -> new HashSet<>())
+										.addAll(slotNames));
 							}
 						}
 					} catch (JsonSyntaxException e) {
-						TrinketsMain.LOGGER
-								.error("[trinkets] Syntax error while reading data for " + identifier.getPath());
+						TrinketsMain.LOGGER.error("[trinkets] Syntax error while reading data for " + identifier.getPath());
 						e.printStackTrace();
 					}
 				}
@@ -106,20 +99,17 @@ public class EntitySlotLoader extends
 	}
 
 	@Override
-	protected void apply(Map<String, Map<String, Set<String>>> loader, ResourceManager manager,
-			Profiler profiler) {
+	protected void apply(Map<String, Map<String, Set<String>>> loader, ResourceManager manager, Profiler profiler) {
 		Map<String, GroupData> slots = SlotLoader.INSTANCE.getSlots();
 		Map<String, Map<String, SlotGroup.Builder>> groupBuilders = new HashMap<>();
 
 		loader.forEach((entityName, groups) -> {
-			Map<String, SlotGroup.Builder> builders = groupBuilders
-					.computeIfAbsent(entityName, (k) -> new HashMap<>());
+			Map<String, SlotGroup.Builder> builders = groupBuilders.computeIfAbsent(entityName, (k) -> new HashMap<>());
 			groups.forEach((groupName, slotNames) -> {
 				GroupData group = slots.get(groupName);
 
 				if (group != null) {
-					SlotGroup.Builder builder = builders
-							.computeIfAbsent(groupName, (k) -> new SlotGroup.Builder(group.getDefaultSlot()));
+					SlotGroup.Builder builder = builders.computeIfAbsent(groupName, (k) -> new SlotGroup.Builder(group.getDefaultSlot()));
 					slotNames.forEach(slotName -> {
 						SlotData slotData = group.getSlot(slotName);
 
@@ -130,8 +120,7 @@ public class EntitySlotLoader extends
 						}
 					});
 				} else {
-					TrinketsMain.LOGGER
-							.error("[trinkets] Attempted to assign slot from unknown group " + groupName);
+					TrinketsMain.LOGGER.error("[trinkets] Attempted to assign slot from unknown group " + groupName);
 				}
 			});
 		});
@@ -141,13 +130,10 @@ public class EntitySlotLoader extends
 			EntityType<?> type = Registry.ENTITY_TYPE.getOrEmpty(new Identifier(entityName)).orElse(null);
 
 			if (type != null) {
-				Map<String, SlotGroup> entitySlots = this.slots
-						.computeIfAbsent(type, (k) -> new HashMap<>());
-				groups.forEach(
-						(groupName, groupBuilder) -> entitySlots.putIfAbsent(groupName, groupBuilder.build()));
+				Map<String, SlotGroup> entitySlots = this.slots.computeIfAbsent(type, (k) -> new HashMap<>());
+				groups.forEach((groupName, groupBuilder) -> entitySlots.putIfAbsent(groupName, groupBuilder.build()));
 			} else {
-				TrinketsMain.LOGGER
-						.error("[trinkets] Attempted to assign slots to unknown entity " + entityName);
+				TrinketsMain.LOGGER.error("[trinkets] Attempted to assign slots to unknown entity " + entityName);
 			}
 		});
 	}

--- a/src/main/java/dev/emi/trinkets/data/SlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/SlotLoader.java
@@ -25,16 +25,13 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
 
-public class SlotLoader extends
-		SinglePreparationResourceReloadListener<Map<String, GroupData>> implements
-		IdentifiableResourceReloadListener {
+public class SlotLoader extends SinglePreparationResourceReloadListener<Map<String, GroupData>> implements IdentifiableResourceReloadListener {
 
 	public static final SlotLoader INSTANCE = new SlotLoader();
 
 	static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "slots");
 
-	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping()
-			.create();
+	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping().create();
 	private static final int FILE_SUFFIX_LENGTH = ".json".length();
 
 	private Map<String, GroupData> slots = new HashMap<>();
@@ -44,18 +41,15 @@ public class SlotLoader extends
 		Map<String, GroupData> map = new HashMap<>();
 		String dataType = "slots";
 
-		for (Identifier identifier : resourceManager
-				.findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
+		for (Identifier identifier : resourceManager.findResources(dataType, (stringx) -> stringx.endsWith(".json"))) {
 
 			try {
-				InputStreamReader reader = new InputStreamReader(
-						resourceManager.getResource(identifier).getInputStream());
+				InputStreamReader reader = new InputStreamReader(resourceManager.getResource(identifier).getInputStream());
 				JsonObject jsonObject = JsonHelper.deserialize(GSON, reader, JsonObject.class);
 
 				if (jsonObject != null) {
 					String path = identifier.getPath();
-					String[] parsed = path
-							.substring(dataType.length() + 1, path.length() - FILE_SUFFIX_LENGTH).split("/");
+					String[] parsed = path.substring(dataType.length() + 1, path.length() - FILE_SUFFIX_LENGTH).split("/");
 					String groupName = parsed[0];
 					String fileName = parsed[parsed.length - 1];
 					GroupData group = map.computeIfAbsent(groupName, (k) -> new GroupData());
@@ -124,10 +118,8 @@ public class SlotLoader extends
 
 		SlotType create(String group, String name) {
 			Identifier finalIcon = new Identifier(icon);
-			Set<Identifier> finalValidators = validators.stream().map(Identifier::new)
-					.collect(Collectors.toSet());
-			return new SlotType(group, name, order, amount, locked, finalIcon, transferable,
-					finalValidators, DropRule.valueOf(dropRule));
+			Set<Identifier> finalValidators = validators.stream().map(Identifier::new).collect(Collectors.toSet());
+			return new SlotType(group, name, order, amount, locked, finalIcon, transferable, finalValidators, DropRule.valueOf(dropRule));
 		}
 
 		void read(JsonObject jsonObject) {

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -1,14 +1,9 @@
 package dev.emi.trinkets.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketEnums;
+import dev.emi.trinkets.api.TrinketEnums.DropRule;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -19,10 +14,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Pair;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
  * Trinket dropping on death
- * 
+ *
  * @author Emi
  */
 @Mixin(LivingEntity.class)
@@ -31,48 +30,49 @@ public abstract class LivingEntityMixin extends Entity {
 	protected LivingEntityMixin(EntityType<? extends LivingEntity> entityType, World world) {
 		super(entityType, world);
 	}
-	
+
 	@Inject(at = @At("TAIL"), method = "dropInventory")
 	public void dropInventory(CallbackInfo info) {
 		boolean keepInv = this.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY);
 		LivingEntity entity = (LivingEntity) (Object) this;
-		TrinketInventory inv = TrinketsMain.TRINKETS.get(entity).getInventory();
-		for (int i = 0; i < inv.size(); i++) {
-			ItemStack stack = inv.getStack(i);
-			if (stack.isEmpty()) {
-				continue;
-			}
+		TrinketsApi.getTrinketComponent(entity).ifPresent(trinkets -> {
+			TrinketInventory inv = trinkets.getInventory();
+			for (int i = 0; i < inv.size(); i++) {
+				ItemStack stack = inv.getStack(i);
+				if (stack.isEmpty()) {
+					continue;
+				}
 
-			TrinketEnums.DropRule dropRule = TrinketEnums.DropRule.DEFAULT;
-			Pair<SlotType, Integer> p = inv.posMap.get(i);
-			if (TrinketsApi.hasTrinket(stack.getItem())) {
-				dropRule = TrinketsApi.getTrinket(stack.getItem()).getDropRule(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), entity);
-			}
-			if (dropRule == TrinketEnums.DropRule.DEFAULT) {
-				dropRule = p.getLeft().getDropRule();
-			}
-			if (dropRule == TrinketEnums.DropRule.DEFAULT) {
-				if (keepInv && this.getType() == EntityType.PLAYER) {
-					dropRule = TrinketEnums.DropRule.ALWAYS_KEEP;
-				} else {
-					if (EnchantmentHelper.hasVanishingCurse(stack)) {
-						dropRule = TrinketEnums.DropRule.DESTROY;
+				Pair<SlotType, Integer> p = inv.posMap.get(i);
+				TrinketEnums.DropRule dropRule = TrinketsApi.getTrinket(stack.getItem())
+						.map(trinket -> trinket.getDropRule(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), entity)).orElse(DropRule.DEFAULT);
+
+				if (dropRule == TrinketEnums.DropRule.DEFAULT) {
+					dropRule = p.getLeft().getDropRule();
+				}
+				if (dropRule == TrinketEnums.DropRule.DEFAULT) {
+					if (keepInv && this.getType() == EntityType.PLAYER) {
+						dropRule = TrinketEnums.DropRule.ALWAYS_KEEP;
 					} else {
-						dropRule = TrinketEnums.DropRule.ALWAYS_DROP;
+						if (EnchantmentHelper.hasVanishingCurse(stack)) {
+							dropRule = TrinketEnums.DropRule.DESTROY;
+						} else {
+							dropRule = TrinketEnums.DropRule.ALWAYS_DROP;
+						}
 					}
 				}
-			}
 
-			switch (dropRule) {
-				case ALWAYS_DROP:
-					dropStack(stack);
-					// Fallthrough
-				case DESTROY:
-					inv.setStack(i, ItemStack.EMPTY);
-					break;
-				default:
-					break;
+				switch (dropRule) {
+					case ALWAYS_DROP:
+						dropStack(stack);
+						// Fallthrough
+					case DESTROY:
+						inv.setStack(i, ItemStack.EMPTY);
+						break;
+					default:
+						break;
+				}
 			}
-		}
+		});
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerEntityRendererMixin.java
@@ -13,6 +13,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+/**
+ * Adds the trinket feature renderer to the list of player features
+ *
+ * @author C4
+ */
 @Environment(EnvType.CLIENT)
 @Mixin(PlayerEntityRenderer.class)
 public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerEntityRendererMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerEntityRendererMixin.java
@@ -1,0 +1,28 @@
+package dev.emi.trinkets.mixin;
+
+import dev.emi.trinkets.TrinketFeatureRenderer;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.network.AbstractClientPlayerEntity;
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.client.render.entity.PlayerEntityRenderer;
+import net.minecraft.client.render.entity.model.PlayerEntityModel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Environment(EnvType.CLIENT)
+@Mixin(PlayerEntityRenderer.class)
+public abstract class PlayerEntityRendererMixin extends LivingEntityRenderer<AbstractClientPlayerEntity, PlayerEntityModel<AbstractClientPlayerEntity>> {
+
+	public PlayerEntityRendererMixin(EntityRenderDispatcher dispatcher, PlayerEntityModel<AbstractClientPlayerEntity> model, float f) {
+		super(dispatcher, model, f);
+	}
+
+	@Inject(at = @At("RETURN"), method = "<init>(Lnet/minecraft/client/render/entity/EntityRenderDispatcher;Z)V")
+	public void init(EntityRenderDispatcher dispatcher, boolean b, CallbackInfo info) {
+		this.addFeature(new TrinketFeatureRenderer(this));
+	}
+}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerInventoryMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerInventoryMixin.java
@@ -1,13 +1,5 @@
 package dev.emi.trinkets.mixin;
 
-import org.spongepowered.asm.mixin.Final;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketInventory;
@@ -16,26 +8,35 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Pair;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
  * Ticks trinkets
- * 
+ *
  * @author Emi
  */
 @Mixin(PlayerInventory.class)
 public class PlayerInventoryMixin {
-	@Shadow @Final
+
+	@Shadow
+	@Final
 	public PlayerEntity player;
-	
+
 	@Inject(at = @At("TAIL"), method = "updateItems")
 	public void updateItems(CallbackInfo info) {
-		TrinketInventory inv = TrinketsMain.TRINKETS.get(player).getInventory();
-		for (int i = 0; i < inv.size(); i++) {
-			ItemStack stack = inv.getStack(i);
-			if (TrinketsApi.hasTrinket(stack.getItem())) {
+		TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> {
+			TrinketInventory inv = trinkets.getInventory();
+
+			for (int i = 0; i < inv.size(); i++) {
+				ItemStack stack = inv.getStack(i);
 				Pair<SlotType, Integer> p = inv.posMap.get(i);
-				TrinketsApi.getTrinket(stack.getItem()).tick(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), player);
+				TrinketsApi.getTrinket(stack.getItem()).ifPresent(trinket -> trinket.tick(stack, new Trinket.SlotReference(p.getLeft(), p.getRight()), player));
 			}
-		}
+		});
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -1,26 +1,26 @@
 package dev.emi.trinkets.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketsApi;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.screen.slot.Slot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
  * Adds trinket slots to the player's screen handler
- * 
- * @author Emi 
+ *
+ * @author Emi
  */
 @Mixin(PlayerScreenHandler.class)
 public abstract class PlayerScreenHandlerMixin extends ScreenHandler {
+
 	public int trinketSlotStart;
 
 	protected PlayerScreenHandlerMixin(ScreenHandlerType<?> type, int syncId) {
@@ -30,9 +30,12 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler {
 	@Inject(at = @At("RETURN"), method = "<init>")
 	public void init(PlayerInventory playerInv, boolean onServer, PlayerEntity owner, CallbackInfo info) {
 		trinketSlotStart = slots.size();
-		TrinketInventory inv = TrinketsMain.TRINKETS.get(owner).getInventory();
-		for (int i = 0; i < inv.size(); i++) {
-			this.addSlot(new Slot(inv, i, i * 16, 0)); // TODO actually do something reasonable with the slots
-		}
+		TrinketsApi.getTrinketComponent(owner).ifPresent(trinkets -> {
+			TrinketInventory inv = trinkets.getInventory();
+
+			for (int i = 0; i < inv.size(); i++) {
+				this.addSlot(new Slot(inv, i, i * 16, 0)); // TODO actually do something reasonable with the slots
+			}
+		});
 	}
 }

--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -8,6 +8,7 @@
 		"LivingEntityMixin"
 	],
 	"client": [
+		"PlayerEntityRendererMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
* Move the Trinket `ComponentKey` from `TrinketsMain` to `TrinketsApi`
* Refactor `getTrinket` to return an `Optional` value to designate to developers that they need to be aware of obtaining empty states
* Add `getTrinketComponent` that basically wraps CCA's `Component.maybeGet` function for the trinket component and refactor some existing logic to use this new function
* Set up the logic for registering trinket renderers and rendering them, mainly in `TrinketRenderer`, `TrinketRendererRegistry`, and `PlayerEntityRendererMixin`