### PR TITLE
Update to Cardinal Components API V3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,11 +35,11 @@ dependencies {
 	// You may need to force-disable transitiveness on them.
 	
 	//Base
-	modCompile "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:2.5.0"
-	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:2.5.0"
+	modApi "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
+	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
 	//Entity
-	modCompile "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:2.5.0"
-	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:2.5.0"
+	modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
+	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
 
 	//modRuntime ("com.github.SuperCoder7979:databreaker:0.2.5") {
 	//	exclude module : "fabric-loader"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.18.0+build.397-1.16
+	cca_version=2.7.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -1,25 +1,17 @@
 package dev.emi.trinkets;
 
-import dev.emi.trinkets.api.Trinket;
-import dev.emi.trinkets.api.PlayerTrinketComponent;
-import dev.emi.trinkets.api.SlotGroups;
-import dev.emi.trinkets.api.Slots;
-import dev.emi.trinkets.api.TrinketSlots;
-import dev.emi.trinkets.api.TrinketsApi;
-import nerdhub.cardinal.components.api.event.EntityComponentCallback;
-import nerdhub.cardinal.components.api.util.EntityComponents;
+import dev.emi.trinkets.api.*;
+import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
+import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 
-public class TrinketsMain implements ModInitializer {
+public class TrinketsMain implements ModInitializer, EntityComponentInitializer {
 	
 	@Override
 	public void onInitialize() {
-		EntityComponentCallback.event(PlayerEntity.class).register((player, components) -> components.put(TrinketsApi.TRINKETS, new PlayerTrinketComponent(player)));
-		EntityComponents.setRespawnCopyStrategy(TrinketsApi.TRINKETS, RespawnCopyStrategy.INVENTORY);
 		TrinketSlots.addSlot(SlotGroups.CHEST, Slots.CAPE, new Identifier("trinkets", "textures/item/empty_trinket_slot_cape.png"), (slot, stack) -> {
 			if (!(stack.getItem() instanceof Trinket)) {
 				return stack.getItem() == Items.ELYTRA;
@@ -34,5 +26,10 @@ public class TrinketsMain implements ModInitializer {
 		//TrinketSlots.addSlot("hand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
 		//TrinketSlots.addSlot("hand", "gloves", new Identifier("trinkets", "textures/item/empty_trinket_slot_gloves.png"));
 		//TrinketSlots.addSlot("offhand", "ring", new Identifier("trinkets", "textures/item/empty_trinket_slot_ring.png"));
+	}
+
+	@Override
+	public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
+		registry.registerForPlayers(TrinketsApi.TRINKETS, PlayerTrinketComponent::new, RespawnCopyStrategy.INVENTORY);
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/PlayerTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/PlayerTrinketComponent.java
@@ -1,23 +1,21 @@
 package dev.emi.trinkets.api;
 
-import java.util.Iterator;
-import java.util.List;
-
 import dev.emi.trinkets.TrinketsClient;
 import dev.emi.trinkets.api.TrinketSlots.Slot;
 import dev.emi.trinkets.api.TrinketSlots.SlotGroup;
-import nerdhub.cardinal.components.api.ComponentType;
-import nerdhub.cardinal.components.api.util.sync.EntitySyncedComponent;
-import net.minecraft.entity.Entity;
+import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 
+import java.util.Iterator;
+import java.util.List;
+
 /**
  * TrinketComponent implemented for players
  */
-public class PlayerTrinketComponent implements TrinketComponent, EntitySyncedComponent {
+public class PlayerTrinketComponent implements TrinketComponent, AutoSyncedComponent {
 	private Inventory inventory;
 	private PlayerEntity player;
 
@@ -27,7 +25,7 @@ public class PlayerTrinketComponent implements TrinketComponent, EntitySyncedCom
 	}
 
 	@Override
-	public void fromTag(CompoundTag tag) {
+	public void readFromNbt(CompoundTag tag) {
 		List<String> keys = TrinketSlots.getAllSlotNames();
 		Iterator<String> iterator = tag.getKeys().iterator();
 		while (iterator.hasNext()) {
@@ -48,17 +46,20 @@ public class PlayerTrinketComponent implements TrinketComponent, EntitySyncedCom
 	}
 
 	@Override
-	public CompoundTag toTag(CompoundTag tag) {
+	public void writeToNbt(CompoundTag tag) {
 		List<String> keys = TrinketSlots.getAllSlotNames();
 		for (int i = 0; i < keys.size(); i++) {
 			tag.put(keys.get(i), inventory.getStack(i).toTag(new CompoundTag()));
 		}
-		return tag;
 	}
 
 	@Override
 	public Inventory getInventory() {
 		return inventory;
+	}
+
+	public PlayerEntity getPlayer() {
+		return player;
 	}
 
 	/**
@@ -106,15 +107,5 @@ public class PlayerTrinketComponent implements TrinketComponent, EntitySyncedCom
 			}
 		}
 		return false;
-	}
-
-	@Override
-	public ComponentType<?> getComponentType() {
-		return TrinketsApi.TRINKETS;
-	}
-
-	@Override
-	public Entity getEntity() {
-		return player;
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketComponent.java
@@ -1,6 +1,6 @@
 package dev.emi.trinkets.api;
 
-import nerdhub.cardinal.components.api.component.Component;
+import dev.onyxstudios.cca.api.v3.component.Component;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -1,6 +1,5 @@
 package dev.emi.trinkets.api;
 
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.item.ItemStack;
 
@@ -8,7 +7,7 @@ import net.minecraft.item.ItemStack;
  * Inventory that marks its parent PlayerTrinketComponent dirty and syncs with the server when needed
  */
 public class TrinketInventory extends SimpleInventory {
-	private PlayerTrinketComponent component;
+	private final PlayerTrinketComponent component;
 
 	public TrinketInventory(PlayerTrinketComponent component, int size) {
 		super(size);
@@ -22,18 +21,18 @@ public class TrinketInventory extends SimpleInventory {
 	@Override
 	public void setStack(int i, ItemStack stack) {
 		if (getStack(i).getItem() instanceof Trinket) {
-			((Trinket) getStack(i).getItem()).onUnequip((PlayerEntity) component.getEntity(), getStack(i));
+			((Trinket) getStack(i).getItem()).onUnequip(component.getPlayer(), getStack(i));
 		}
 		super.setStack(i, stack);
 		if(getStack(i).getItem() instanceof Trinket) {
-			((Trinket) getStack(i).getItem()).onEquip((PlayerEntity) component.getEntity(), getStack(i));
+			((Trinket) getStack(i).getItem()).onEquip(component.getPlayer(), getStack(i));
 		}
 	}
 
 	@Override
 	public ItemStack removeStack(int i) {
 		if(getStack(i).getItem() instanceof Trinket){
-			((Trinket) getStack(i).getItem()).onUnequip((PlayerEntity) component.getEntity(), getStack(i));
+			((Trinket) getStack(i).getItem()).onUnequip(component.getPlayer(), getStack(i));
 		}
 		return super.removeStack(i);
 	}
@@ -42,13 +41,13 @@ public class TrinketInventory extends SimpleInventory {
 	public ItemStack removeStack(int i, int count) {
 		ItemStack stack = super.removeStack(i, count);
 		if (!stack.isEmpty() && getStack(i).isEmpty() && stack.getItem() instanceof Trinket) {
-			((Trinket) stack.getItem()).onUnequip((PlayerEntity) component.getEntity(), stack);
+			((Trinket) stack.getItem()).onUnequip(component.getPlayer(), stack);
 		}
 		return stack;
 	}
 
 	@Override
 	public void markDirty() {
-		component.sync();
+		TrinketsApi.TRINKETS.sync(component.getPlayer());
 	}
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,6 +1,6 @@
 package dev.emi.trinkets.api;
 
-import nerdhub.cardinal.components.api.ComponentRegistry;
+import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
 import nerdhub.cardinal.components.api.ComponentType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
@@ -10,7 +10,8 @@ import net.minecraft.util.Identifier;
  * Basic Trinkets calls to get information about players and their trinkets
  */
 public class TrinketsApi {
-	public static final ComponentType<TrinketComponent> TRINKETS = ComponentRegistry.INSTANCE.registerIfAbsent(new Identifier("trinkets:trinkets"), TrinketComponent.class);
+	// TODO replace ComponentType with ComponentKey when binary compatibility is not an issue
+	public static final ComponentType<TrinketComponent> TRINKETS = (ComponentType<TrinketComponent>) ComponentRegistry.getOrCreate(new Identifier("trinkets:trinkets"), TrinketComponent.class);
 
 	/**
 	 * @return An inventory holding all trinket slots indexed numerically

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -1,5 +1,14 @@
 package dev.emi.trinkets.mixin;
 
+import dev.emi.trinkets.TrinketSlot;
+import dev.emi.trinkets.api.*;
+import dev.emi.trinkets.api.TrinketSlots.Slot;
+import dev.emi.trinkets.api.TrinketSlots.SlotGroup;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.screen.AbstractRecipeScreenHandler;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
@@ -8,20 +17,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
-import dev.emi.trinkets.TrinketSlot;
-import dev.emi.trinkets.api.Trinket;
-import dev.emi.trinkets.api.PlayerTrinketComponent;
-import dev.emi.trinkets.api.TrinketComponent;
-import dev.emi.trinkets.api.TrinketSlots;
-import dev.emi.trinkets.api.TrinketsApi;
-import dev.emi.trinkets.api.TrinketSlots.Slot;
-import dev.emi.trinkets.api.TrinketSlots.SlotGroup;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.player.PlayerInventory;
-import net.minecraft.inventory.CraftingInventory;
-import net.minecraft.inventory.Inventory;
-import net.minecraft.item.ItemStack;
 
 /**
  * Adds trinket slots to the PlayerContainer on initialization
@@ -64,7 +59,7 @@ public abstract class PlayerScreenHandlerMixin extends AbstractRecipeScreenHandl
 				} else {
 					if (copy.getItem() instanceof Trinket) {
 						TrinketComponent comp = TrinketsApi.getTrinketComponent(player);
-						((Trinket) copy.getItem()).onUnequip((PlayerEntity) ((PlayerTrinketComponent) comp).getEntity(), copy);
+						((Trinket) copy.getItem()).onUnequip(((PlayerTrinketComponent) comp).getPlayer(), copy);
 					}
 					info.setReturnValue(stack);
 				}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,11 +23,19 @@
 		],
 		"client": [
 			"dev.emi.trinkets.TrinketsClient"
+		],
+		"cardinal-components-entity": [
+			"dev.emi.trinkets.TrinketsMain"
 		]
 	},
 	"mixins": [
 		"trinkets.mixins.json"
 	],
+	"custom": {
+		"cardinal-components": [
+			"trinkets:trinkets"
+		]
+	},
 
 	"depends": {
 		"fabricloader": ">=0.4.0",


### PR DESCRIPTION
With CCA V2 interfaces getting removed in 1.17, now is a fairly good time to switch to V3. The changes are not too impressive, the main one being the [registration mechanism](https://github.com/OnyxStudios/Cardinal-Components-API/wiki/Registering-and-using-a-component).

`ComponentType` is supposed to be replaced with `ComponentKey`, but that would break binary compatibility with the mods that use this API; so I left it with a bit of an awkward cast. You can probably fix that kludge in your own 3.0.0 update.