### PR TITLE
Syncing fix and miscellaneous

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketsNetwork.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsNetwork.java
@@ -5,6 +5,7 @@ import net.minecraft.util.Identifier;
 public class TrinketsNetwork {
 
   public static final Identifier SYNC_SLOTS = new Identifier(TrinketsMain.MOD_ID, "sync_slots");
+  public static final Identifier SYNC_CONTENT = new Identifier(TrinketsMain.MOD_ID, "sync_content");
   public static final Identifier SYNC_MODIFIERS = new Identifier(TrinketsMain.MOD_ID, "sync_modifiers");
   public static final Identifier BREAK = new Identifier(TrinketsMain.MOD_ID, "break");
 


### PR DESCRIPTION
This PR primarily fixes the syncing issue outlined here https://github.com/emilyploszaj/trinkets/issues/113.

The issue arises because we never call `ComponentKey#sync` from CCA, which is what handles the actual syncing.

However, there's a problem with using that. Because we track the Trinket changes externally (in `LivingEntityMixin`), we don't have a good way of providing the data needed for the sync if we try to use the packet writers in `AutoSyncedComponent`. Additionally, trying to use the  `readFromNbt` and `writeToNbt` implementations in `LivingEntityTrinketComponent` actually results in desyncs because those methods currently assume they're being used for entity deserialization and serialization only. Not to mention that syncing _all_ the data every time is needlessly wasteful.

Instead of trying to refactor anything, I tried to just accomplish it in the most straightforward way using our own packets/network to sync it ourselves. This way there's less room for error while keeping the amount of data being transferred in packets to a minimum.

For future reference, I think the best or cleanest solution would involve refactoring the tick method in `LivingEntityMixin` into a new API method `TrinketComponent#tick` and internally handling all of the change listeners in the component so that we can pass it onto new implementations we would write for `AutoSyncedComponent#writeSyncPacket` and `AutoSyncedComponent#applySyncPacket`. However, due to the changes and work necessary, it'd probably be best to shelve the idea until 1.18, if we even need it.

Additionally, the PR restricts both data loaders to the `trinkets` namespace so that erroneous data types do not get loaded and removes a `System.out.println` in the `SlotLoader` that I assume was left there unintentionally (let me know if this is not the case).