### PR TITLE
Fix mixin CreativeInventoryScreenMixin error loading class on server

### DIFF
--- a/src/main/resources/trinkets.mixins.json
+++ b/src/main/resources/trinkets.mixins.json
@@ -4,7 +4,6 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "accessor.ScreenHandlerAccessor",
-    "CreativeInventoryScreenMixin",
     "LivingEntityMixin",
     "PlayerInventoryMixin",
     "PlayerManagerMixin",
@@ -15,6 +14,7 @@
     "accessor.LivingEntityAccessor",
     "ClickableWidgetMixin",
     "ClientPlayNetworkHandlerMixin",
+    "CreativeInventoryScreenMixin",
     "HandledScreenMixin",
     "InventoryScreenMixin",
     "ItemStackMixin",


### PR DESCRIPTION
Changed trinkets.mixins.json so that CreativeInventoryScreenMixin is a client mixin, avoiding the following error message on server:
```
 [main/WARN] (mixin) Error loading class: net/minecraft/client/gui/screen/ingame/CreativeInventoryScreen (java.lang.RuntimeException: Cannot load class net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen in environment type SERVER)
 [main/WARN] (mixin) @Mixin target net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen was not found trinkets.mixins.json:CreativeInventoryScreenMixin 
 ```