### PR TITLE
Update for 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'fabric-loom' version '0.10-SNAPSHOT'
-	//id "com.github.fudge.forgedflowerloom" version "2.0.0"
+	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'io.github.juuxel.loom-quiltflower' version '1.6.0'
 	id 'maven-publish'
 }
 
@@ -13,15 +13,15 @@ group = project.maven_group
 
 
 loom {
-	accessWidener = file("src/main/resources/trinkets.accesswidener")
+	accessWidenerPath = file("src/main/resources/trinkets.accesswidener")
 }
 
 repositories {
+	maven { url = "https://maven.terraformersmc.com" }
 	maven {
 		name = "Ladysnake Libs"
 		url = "https://ladysnake.jfrog.io/artifactory/mods"
 	}
-	maven { url = "https://jitpack.io" }
 }
 
 sourceSets {
@@ -39,19 +39,14 @@ dependencies {
 
 	// Mod dependencies
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
-	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
-	modImplementation "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
-	include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-entity:${project.cca_version}"
+	modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}")
+	modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}")
 
 	// Dev Runtime
 	testmodImplementation sourceSets.main.output
-	/*modRuntime("io.github.prospector:modmenu:${project.mod_menu_version}") {
+	modImplementation("com.terraformersmc:modmenu:${project.mod_menu_version}") {
 		transitive = false
-	}*/
-	//modRuntime ("com.github.SuperCoder7979:databreaker:0.2.5") {
-	//	exclude module : "fabric-loader"
-	//}
+	}
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.1
-loader_version=0.12.12
+minecraft_version=1.18.2-rc1
+yarn_mappings=1.18.2-rc1+build.2
+loader_version=0.13.3
 
-mod_version = 3.2.0
+mod_version = 3.2.0-florens
 maven_group = dev.emi
 archives_base_name = trinkets
 
-fabric_version=0.46.2+1.18
-cca_version=4.0.0
-mod_menu_version=3.0.0
+fabric_version=0.47.8+1.18.2
+cca_version=4.1.3
+mod_menu_version=3.0.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,12 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
+        }
+        maven {
+            name = 'Cotton'
+            url = 'https://server.bbkr.space/artifactory/libs-release/'
         }
         gradlePluginPortal()
     }

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,12 +1,6 @@
 package dev.emi.trinkets.api;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
 import com.mojang.datafixers.util.Function3;
-
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.TrinketsNetwork;
 import dev.emi.trinkets.data.EntitySlotLoader;
@@ -22,9 +16,15 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.tag.ItemTags;
-import net.minecraft.tag.Tag;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
 
 public class TrinketsApi {
 	public static final ComponentKey<TrinketComponent> TRINKET_COMPONENT = ComponentRegistryV3.INSTANCE
@@ -119,12 +119,13 @@ public class TrinketsApi {
 	static {
 		TrinketsApi.registerTrinketPredicate(new Identifier("trinkets", "all"), (stack, ref, entity) -> TriState.TRUE);
 		TrinketsApi.registerTrinketPredicate(new Identifier("trinkets", "none"), (stack, ref, entity) -> TriState.FALSE);
-		Identifier trinketsAll = new Identifier("trinkets", "all");
+		TagKey<Item> trinketsAll = TagKey.of(Registry.ITEM_KEY, new Identifier("trinkets", "all"));
+
 		TrinketsApi.registerTrinketPredicate(new Identifier("trinkets", "tag"), (stack, ref, entity) -> {
 			SlotType slot = ref.inventory().getSlotType();
-			Tag<Item> tag = ItemTags.getTagGroup().getTagOrEmpty(new Identifier("trinkets", slot.getGroup() + "/" + slot.getName()));
-			Tag<Item> all = ItemTags.getTagGroup().getTagOrEmpty(trinketsAll);
-			if (tag.contains(stack.getItem()) || all.contains(stack.getItem())) {
+			TagKey<Item> tag = TagKey.of(Registry.ITEM_KEY, new Identifier("trinkets", slot.getGroup() + "/" + slot.getName()));
+
+			if (stack.isIn(tag) || stack.isIn(trinketsAll)) {
 				return TriState.TRUE;
 			}
 			return TriState.DEFAULT;

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -28,6 +28,7 @@ import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
@@ -35,11 +36,12 @@ import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.SinglePreparationResourceReloader;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.tag.ServerTagManagerHolder;
+import net.minecraft.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryEntry;
 
 public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<String, Map<String, Set<String>>>> implements IdentifiableResourceReloadListener {
 
@@ -135,10 +137,15 @@ public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<Stri
 
 			try {
 				if (entityName.startsWith("#")) {
-					types.addAll(ServerTagManagerHolder.getTagManager().getTag(Registry.ENTITY_TYPE_KEY,
-									new Identifier(entityName.substring(1)),
-									(identifier) -> new IllegalArgumentException("Unknown entity tag '" + identifier + "'"))
-									.values());
+					// FIXME: registry tags not populated yet, might need to make this lazy
+					TagKey<EntityType<?>> tag = TagKey.of(Registry.ENTITY_TYPE_KEY, new Identifier(entityName.substring(1)));
+					List<? extends EntityType<?>> entityTypes = Registry.ENTITY_TYPE.getEntryList(tag)
+							.orElseThrow(() -> new IllegalArgumentException("Unknown entity tag '" + entityName + "'"))
+							.stream()
+							.map(RegistryEntry::value)
+							.toList();
+
+					types.addAll(entityTypes);
 				} else {
 					types.add(Registry.ENTITY_TYPE.getOrEmpty(new Identifier(entityName))
 							.orElseThrow(() -> new IllegalArgumentException("Unknown entity '" + entityName + "'")));

--- a/src/main/java/dev/emi/trinkets/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/ClientPlayNetworkHandlerMixin.java
@@ -5,6 +5,7 @@ import dev.emi.trinkets.api.TrinketInventory;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.network.packet.s2c.play.PlayerRespawnS2CPacket;
+import net.minecraft.util.registry.RegistryEntry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +23,7 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 public class ClientPlayNetworkHandlerMixin {
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;setId(I)V"), method = "onPlayerRespawn", locals = LocalCapture.CAPTURE_FAILSOFT)
-    private void onPlayerRespawn(PlayerRespawnS2CPacket packet, CallbackInfo ci, RegistryKey<?> registryKey, DimensionType dimensionType, ClientPlayerEntity clientPlayerEntity, int i, String string, ClientPlayerEntity clientPlayerEntity2) {
+    private void onPlayerRespawn(PlayerRespawnS2CPacket packet, CallbackInfo ci, RegistryKey<?> registryKey, RegistryEntry<?> registryEntry, ClientPlayerEntity clientPlayerEntity, int i, String string, ClientPlayerEntity clientPlayerEntity2) {
         if (packet.shouldKeepPlayerAttributes()) {
             TrinketInventory.copyFrom(clientPlayerEntity, clientPlayerEntity2);
             ((TrinketPlayerScreenHandler) clientPlayerEntity2.playerScreenHandler).trinkets$updateTrinketSlots(false);

--- a/src/testmod/resources/data/trinkets-testmod/tags/entity_types/some_entities.json
+++ b/src/testmod/resources/data/trinkets-testmod/tags/entity_types/some_entities.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:player",
+    "minecraft:skeleton",
+    "minecraft:creeper"
+  ]
+}

--- a/src/testmod/resources/data/trinkets/entities/trinkets-testmod.json
+++ b/src/testmod/resources/data/trinkets/entities/trinkets-testmod.json
@@ -1,5 +1,5 @@
 {
-  "entities": ["player"],
+  "entities": ["player", "#some_entities,"],
   "slots": [
     "hand/glove",
     "hand/ring",


### PR DESCRIPTION
Only issue so far appears to be getting the list of entity types from an entity type tag in [EntitySlotLoader](https://github.com/florensie/trinkets/blob/d3b86d60d62bdf8f97920456f1ba4c76c83801f8/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java#L140).

One possible solution is to do something like vanilla recipe loading. Create abstract entries (Ingredient.Entry <- StackEntry, TagEntry), which can then be lazily loaded after resource loading is complete.	

~Another solution would be to call getRegistryTags on TagManagerLoader but it appears that getting the instance of that class might be non-trivial.~