### PR TITLE
Slot fixes

### DIFF
--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -141,6 +141,10 @@ public class TrinketInventory implements Inventory {
 		}
 	}
 
+	public void removeCachedModifier(EntityAttributeModifier attributeModifier) {
+		this.cachedModifiers.remove(attributeModifier);
+	}
+
 	public void clearCachedModifiers() {
 		for (EntityAttributeModifier cachedModifier : this.cachedModifiers) {
 			this.removeModifier(cachedModifier.getId());

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -140,7 +140,6 @@ public abstract class LivingEntityMixin extends Entity {
 		TrinketsApi.getTrinketComponent(entity).ifPresent(trinkets -> {
 			Map<String, ItemStack> newlyEquippedTrinkets = new HashMap<>();
 			Map<String, ItemStack> contentUpdates = new HashMap<>();
-			trinkets.clearCachedModifiers();
 			trinkets.forEach((ref, stack) -> {
 				TrinketInventory inventory = ref.inventory();
 				SlotType slotType = inventory.getSlotType();

--- a/src/main/resources/data/trinkets/slots/chest/back.json
+++ b/src/main/resources/data/trinkets/slots/chest/back.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/back",
-  "order": -512
+  "order": -512,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/chest/back.json
+++ b/src/main/resources/data/trinkets/slots/chest/back.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/back",
   "order": -512,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/chest/cape.json
+++ b/src/main/resources/data/trinkets/slots/chest/cape.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/cape",
-  "order": -256
+  "order": -256,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/chest/cape.json
+++ b/src/main/resources/data/trinkets/slots/chest/cape.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/cape",
   "order": -256,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/chest/necklace.json
+++ b/src/main/resources/data/trinkets/slots/chest/necklace.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/necklace",
   "order": -1024,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/chest/necklace.json
+++ b/src/main/resources/data/trinkets/slots/chest/necklace.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/necklace",
-  "order": -1024
+  "order": -1024,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/feet/aglet.json
+++ b/src/main/resources/data/trinkets/slots/feet/aglet.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/aglet",
   "order": -1024,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/feet/aglet.json
+++ b/src/main/resources/data/trinkets/slots/feet/aglet.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/aglet",
-  "order": -1024
+  "order": -1024,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/feet/shoes.json
+++ b/src/main/resources/data/trinkets/slots/feet/shoes.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/shoes",
   "order": -512,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/feet/shoes.json
+++ b/src/main/resources/data/trinkets/slots/feet/shoes.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/shoes",
-  "order": -512
+  "order": -512,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/hand/glove.json
+++ b/src/main/resources/data/trinkets/slots/hand/glove.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/glove",
   "order": -1024,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/hand/glove.json
+++ b/src/main/resources/data/trinkets/slots/hand/glove.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/glove",
-  "order": -1024
+  "order": -1024,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/hand/ring.json
+++ b/src/main/resources/data/trinkets/slots/hand/ring.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/ring",
   "order": -512,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/hand/ring.json
+++ b/src/main/resources/data/trinkets/slots/hand/ring.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/ring",
-  "order": -512
+  "order": -512,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/head/face.json
+++ b/src/main/resources/data/trinkets/slots/head/face.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/face",
-  "order": -1024
+  "order": -1024,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/head/face.json
+++ b/src/main/resources/data/trinkets/slots/head/face.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/face",
   "order": -1024,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/head/hat.json
+++ b/src/main/resources/data/trinkets/slots/head/hat.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/hat",
   "order": -512,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/head/hat.json
+++ b/src/main/resources/data/trinkets/slots/head/hat.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/hat",
-  "order": -512
+  "order": -512,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/legs/belt.json
+++ b/src/main/resources/data/trinkets/slots/legs/belt.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/belt",
-  "order": -1024
+  "order": -1024,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/legs/belt.json
+++ b/src/main/resources/data/trinkets/slots/legs/belt.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/belt",
   "order": -1024,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/offhand/glove.json
+++ b/src/main/resources/data/trinkets/slots/offhand/glove.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/glove_mirrored",
   "order": -512,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/offhand/glove.json
+++ b/src/main/resources/data/trinkets/slots/offhand/glove.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/glove_mirrored",
-  "order": -512
+  "order": -512,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }

--- a/src/main/resources/data/trinkets/slots/offhand/ring.json
+++ b/src/main/resources/data/trinkets/slots/offhand/ring.json
@@ -1,7 +1,5 @@
 {
   "icon": "trinkets:gui/slots/ring",
   "order": -1024,
-  "validator_predicates": ["trinkets:tag"],
-  "quick_move_predicates": ["trinkets:all"],
-  "tooltip_predicates": ["trinkets:all"]
+  "validator_predicates": ["trinkets:tag"]
 }

--- a/src/main/resources/data/trinkets/slots/offhand/ring.json
+++ b/src/main/resources/data/trinkets/slots/offhand/ring.json
@@ -1,4 +1,7 @@
 {
   "icon": "trinkets:gui/slots/ring",
-  "order": -1024
+  "order": -1024,
+  "validator_predicates": ["trinkets:tag"],
+  "quick_move_predicates": ["trinkets:all"],
+  "tooltip_predicates": ["trinkets:all"]
 }


### PR DESCRIPTION
This is a PR discussed briefly over Discord before. In summary, this PR addresses two fairly niche slot issues.

Firstly, default slots get all of its default predicates overwritten if any mod attempts to implement additional predicates. This is due to the fact that the default predicates are only assigned if the predicates are empty to begin with. 

https://github.com/emilyploszaj/trinkets/blob/366f80866ad978b1204785333c6d210b1dd9d786/src/main/java/dev/emi/trinkets/data/SlotLoader.java#L142-L150

Related issue from my Trinket Shulker Boxes mod: https://github.com/TheIllusiveC4/CuriousShulkerBoxes/issues/16

While there are many potential solutions, it was decided that the easiest and most straightforward method was to explicitly define the default predicates in the provided default slot json files.

Secondly, slot modifiers will not accurately persist across loads. This causes items in slots given by modifiers to be placed back into the player's inventory upon reloading into a world despite the fact that the slots still seem to exist. This occurs because although the modifiers are correctly saved and loaded, they are cleared and then re-applied in the first tick.

https://github.com/emilyploszaj/trinkets/blob/366f80866ad978b1204785333c6d210b1dd9d786/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java#L143

My proposed solution involves moving this logic to the end of `LivingEntityTrinketComponent#readFromNbt`. Once the initial data is read and loaded, all of the slot modifiers from the worn items are read and then subsequently removed from the modifiers enqueued for removal. Essentially, this is saying "these are the slot modifiers we had before, here are the items we have now, keep the slot modifiers from those items and remove the rest, then proceed with first tick." Doing it this way also ensures that items that have changed their slot modifiers due to a mod update will propagate those changes correctly.

I tested the first change with Inmis and Trinket Shulker Boxes and it does correctly solve the issue so that items from both mods are equippable again when loaded together. I tested the second change with the Trinkets test mod: I wore the item to give more ring slots, added diamonds as a ring item, and then placed diamonds in all of the ring slots. Relogging keeps the diamonds in place. I also tested both changes with Botania loaded to make sure it didn't somehow adversely affect other trinkets.