### PR TITLE
[1.19]: Fix for Crash within SinglePlayer during the /reload command

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -33,8 +33,8 @@ public interface TrinketPlayerScreenHandler {
 
 	int trinkets$getTrinketSlotEnd();
 
-	boolean shouldReRenderScreen();
+	boolean trinkets$shouldReRenderScreen();
 
-	void setReRenderScreen(boolean reRender);
+	void trinkets$setReRenderScreen(boolean reRender);
 
 }

--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -1,9 +1,11 @@
 package dev.emi.trinkets;
 
 import java.util.List;
+import java.util.Map;
 
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
+import net.minecraft.screen.slot.Slot;
 
 /**
  * Interface for putting methods onto the player's screen handler
@@ -30,4 +32,9 @@ public interface TrinketPlayerScreenHandler {
 	int trinkets$getTrinketSlotStart();
 
 	int trinkets$getTrinketSlotEnd();
+
+	boolean shouldReRenderScreen();
+
+	void setReRenderScreen(boolean reRender);
+
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotGroup.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotGroup.java
@@ -5,6 +5,7 @@ import net.minecraft.nbt.NbtCompound;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public final class SlotGroup {
 
@@ -71,21 +72,16 @@ public final class SlotGroup {
 	}
 
 	@Override
-	public int hashCode() {
-		int hash = name.hashCode();
-
-		hash = 31 * hash + slots.hashCode();
-
-		return hash;
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		SlotGroup slotGroup = (SlotGroup) o;
+		return slotId == slotGroup.slotId && order == slotGroup.order && name.equals(slotGroup.name) && slots.equals(slotGroup.slots);
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if(obj instanceof SlotGroup slotGroup){
-			return slotGroup.name.equals(name) && slotGroup.slots.equals(slots);
-		}
-
-		return super.equals(obj);
+	public int hashCode() {
+		return Objects.hash(name, slotId, order, slots);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/SlotGroup.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotGroup.java
@@ -70,6 +70,29 @@ public final class SlotGroup {
 		return builder.build();
 	}
 
+	@Override
+	public int hashCode() {
+		int hash = name.hashCode();
+
+		hash = 31 * hash + slots.hashCode();
+
+		return hash;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(obj instanceof SlotGroup slotGroup){
+			return slotGroup.name.equals(name) && slotGroup.slots.equals(slots);
+		}
+
+		return super.equals(obj);
+	}
+
+	@Override
+	public String toString() {
+		return this.name + " / " + this.slots;
+	}
+
 	public static class Builder {
 
 		private final String name;

--- a/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
@@ -2,7 +2,6 @@ package dev.emi.trinkets.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -93,10 +92,10 @@ public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScre
 			TrinketScreenManager.update(mouseX, mouseY);
 		}
 
-		if(trinkets$getHandler().shouldReRenderScreen()){
+		if(trinkets$getHandler().trinkets$shouldReRenderScreen()){
 			this.clearAndInit();
 
-			trinkets$getHandler().setReRenderScreen(false);
+			trinkets$getHandler().trinkets$setReRenderScreen(false);
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
@@ -2,6 +2,7 @@ package dev.emi.trinkets.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -90,6 +91,12 @@ public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScre
 	private void render(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo info) {
 		if (selectedTab == ItemGroup.INVENTORY.getIndex()) {
 			TrinketScreenManager.update(mouseX, mouseY);
+		}
+
+		if(trinkets$getHandler().shouldReRenderScreen()){
+			this.clearAndInit();
+
+			trinkets$getHandler().setReRenderScreen(false);
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
@@ -1,6 +1,7 @@
 package dev.emi.trinkets.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -47,6 +48,13 @@ public abstract class InventoryScreenMixin extends AbstractInventoryScreen<Playe
 	@Inject(at = @At("HEAD"), method = "render")
 	private void render(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo info) {
 		TrinketScreenManager.update(mouseX, mouseY);
+
+		if(trinkets$getHandler().shouldReRenderScreen()){
+			// Force the screen to re-render until the group exists within the map
+			this.clearAndInit();
+
+			trinkets$getHandler().setReRenderScreen(false);
+		}
 	}
 
 	@Inject(at = @At(value = "INVOKE", target = "net/minecraft/client/gui/screen/ingame/InventoryScreen.drawEntity(IIIFFLnet/minecraft/entity/LivingEntity;)V"), method = "drawBackground")

--- a/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
@@ -1,7 +1,6 @@
 package dev.emi.trinkets.mixin;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -49,11 +48,11 @@ public abstract class InventoryScreenMixin extends AbstractInventoryScreen<Playe
 	private void render(MatrixStack matrices, int mouseX, int mouseY, float delta, CallbackInfo info) {
 		TrinketScreenManager.update(mouseX, mouseY);
 
-		if(trinkets$getHandler().shouldReRenderScreen()){
+		if(trinkets$getHandler().trinkets$shouldReRenderScreen()){
 			// Force the screen to re-render until the group exists within the map
 			this.clearAndInit();
 
-			trinkets$getHandler().setReRenderScreen(false);
+			trinkets$getHandler().trinkets$setReRenderScreen(false);
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -79,7 +79,7 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 
 				//Will Cause a client to redraw the screen(if opened during a reload) now that the data is available
 				if(owner.getWorld().isClient){
-					this.setReRenderScreen(true);
+					this.trinkets$setReRenderScreen(true);
 				}
 			}
 			Map<String, SlotGroup> groups = trinkets.getGroups();
@@ -217,12 +217,12 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 	}
 
 	@Override
-	public void setReRenderScreen(boolean reRenderScreen) {
+	public void trinkets$setReRenderScreen(boolean reRenderScreen) {
 		this.reRenderScreen = reRenderScreen;
 	}
 
 	@Override
-	public boolean shouldReRenderScreen() {
+	public boolean trinkets$shouldReRenderScreen() {
 		return this.reRenderScreen;
 	}
 


### PR DESCRIPTION
Fixes a bug where for whatever reason within a single player world, the client player's screen handler will have data within the maps but during the /reload, new SlotGroup's are made which a very different instances compared to the ones within the given maps causing null values to be passed causing a crash if the CreativeScreen or Inventory Screen is open.

Should fix #175 

Pr Adds:
- Comparison Methods to the SlotGroup class
- Force Redraw of the Players Inventory Screen if opened 