### PR TITLE
[1.19]: Fix for Crash within SinglePlayer during the /reload command with NPE

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -30,4 +30,6 @@ public interface TrinketPlayerScreenHandler {
 	int trinkets$getTrinketSlotStart();
 
 	int trinkets$getTrinketSlotEnd();
+
+	boolean trinkets$isSane(SlotGroup group);
 }

--- a/src/main/java/dev/emi/trinkets/TrinketScreen.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreen.java
@@ -22,4 +22,6 @@ public interface TrinketScreen {
 
 	public default void trinkets$updateTrinketSlots() {
 	}
+
+	void trinkets$markDirty();
 }

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -36,6 +36,14 @@ public class TrinketScreenManager {
 
 	public static void update(float mouseX, float mouseY) {
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
+
+		if((group != null && !handler.trinkets$isSane(group))
+			|| (quickMoveGroup != null && !handler.trinkets$isSane(quickMoveGroup))
+			|| (TrinketsClient.activeGroup != null && !handler.trinkets$isSane(TrinketsClient.activeGroup))
+			|| (TrinketsClient.quickMoveGroup != null && !handler.trinkets$isSane(TrinketsClient.quickMoveGroup))){
+			return;
+		}
+
 		Slot focusedSlot = currentScreen.trinkets$getFocusedSlot();
 		int x = currentScreen.trinkets$getX();
 		int y = currentScreen.trinkets$getY();
@@ -108,6 +116,10 @@ public class TrinketScreenManager {
 			group = TrinketsClient.activeGroup;
 
 			if (group != null) {
+				if(!handler.trinkets$isSane(group)){
+					return;
+				}
+
 				int slotsWidth = handler.trinkets$getSlotWidth(group) + 1;
 				if (group.getSlotId() == -1) slotsWidth -= 1;
 				Rect2i r = currentScreen.trinkets$getGroupRect(group);
@@ -141,6 +153,10 @@ public class TrinketScreenManager {
 			quickMoveGroup = TrinketsClient.quickMoveGroup;
 
 			if (quickMoveGroup != null) {
+				if(!handler.trinkets$isSane(quickMoveGroup)){
+					return;
+				}
+
 				int slotsWidth = handler.trinkets$getSlotWidth(quickMoveGroup) + 1;
 
 				if (quickMoveGroup.getSlotId() == -1) slotsWidth -= 1;
@@ -175,6 +191,11 @@ public class TrinketScreenManager {
 
 	public static void drawGroup(DrawableHelper helper, MatrixStack matrices, SlotGroup group, SlotType type) {
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
+
+		if (!handler.trinkets$isSane(group)) {
+			return;
+		}
+
 		RenderSystem.enableDepthTest();
 		helper.setZOffset(305);
 

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -135,6 +135,10 @@ public class TrinketsClient implements ClientModInitializer {
 						for (AbstractClientPlayerEntity clientWorldPlayer : player.clientWorld.getPlayers()) {
 							((TrinketPlayerScreenHandler) clientWorldPlayer.playerScreenHandler).trinkets$updateTrinketSlots(true);
 						}
+
+						if(client.currentScreen instanceof TrinketScreen trinketScreen){
+							trinketScreen.trinkets$markDirty();
+						}
 					}
 				});
 			}

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -1,10 +1,6 @@
 package dev.emi.trinkets.mixin;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -44,15 +40,15 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 	private PlayerEntity owner;
 
 	@Unique
-	private final Map<SlotGroup, Integer> groupNums = new HashMap<>();
+	private final Map<SlotGroup, Integer> groupNums = new IdentityHashMap<>();
 	@Unique
-	private final Map<SlotGroup, Point> groupPos = new HashMap<>();
+	private final Map<SlotGroup, Point> groupPos = new IdentityHashMap<>();
 	@Unique
-	private final Map<SlotGroup, List<Point>> slotHeights = new HashMap<>();
+	private final Map<SlotGroup, List<Point>> slotHeights = new IdentityHashMap<>();
 	@Unique
-	private final Map<SlotGroup, List<SlotType>> slotTypes = new HashMap<>();
+	private final Map<SlotGroup, List<SlotType>> slotTypes = new IdentityHashMap<>();
 	@Unique
-	private final Map<SlotGroup, Integer> slotWidths = new HashMap<>();
+	private final Map<SlotGroup, Integer> slotWidths = new IdentityHashMap<>();
 	@Unique
 	private int trinketSlotStart = 0;
 	@Unique
@@ -193,6 +189,15 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 	@Override
 	public int trinkets$getSlotWidth(SlotGroup group) {
 		return slotWidths.get(group);
+	}
+
+	@Override
+	public boolean trinkets$isSane(SlotGroup group) {
+		return groupNums.containsKey(group)
+				&& groupPos.containsKey(group)
+				&& slotHeights.containsKey(group)
+				&& slotTypes.containsKey(group)
+				&& slotWidths.containsKey(group);
 	}
 
 	@Override


### PR DESCRIPTION
Part two: Electric Boogaloo

Explanation: 

The NPE comes from a Singleton issue with both the Server and the Client sharing the EntitySlotLoader.INSTANCE variable due to running on the same JVM in Single Player World. Meaning the when the Server updates the EntityType map for slots, the client is instantly updated but the components are yet to update causing a delay allowing for atleast a frame to be rendered leading to the Null Pointer Exception

Without the Help from @gliscowo  I would have never been able to understand the underline problem.