### PR TITLE
Split entity slot loader into logical sides and fix desyncs

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
+++ b/src/main/java/dev/emi/trinkets/TrinketPlayerScreenHandler.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Interface for putting methods onto the player's screen handler
@@ -17,10 +19,16 @@ public interface TrinketPlayerScreenHandler {
 
 	int trinkets$getGroupNum(SlotGroup group);
 
+	@Nullable
 	Point trinkets$getGroupPos(SlotGroup group);
 
+	@Nonnull
 	List<Point> trinkets$getSlotHeights(SlotGroup group);
 
+	@Nullable
+	Point trinkets$getSlotHeight(SlotGroup group, int i);
+
+	@Nonnull
 	List<SlotType> trinkets$getSlotTypes(SlotGroup group);
 
 	int trinkets$getSlotWidth(SlotGroup group);

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -1,11 +1,13 @@
 package dev.emi.trinkets;
 
+import dev.emi.trinkets.data.EntitySlotLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Pair;
@@ -18,7 +20,6 @@ import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
-import dev.emi.trinkets.data.EntitySlotLoader;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -126,11 +127,15 @@ public class TrinketsClient implements ClientModInitializer {
 					});
 				}
 				client.execute(() -> {
-					EntitySlotLoader.INSTANCE.setSlots(slots);
+					EntitySlotLoader.CLIENT.setSlots(slots);
 					ClientPlayerEntity player = client.player;
 
 					if (player != null) {
 						((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(true);
+
+						if (client.currentScreen instanceof TrinketScreen trinketScreen) {
+							trinketScreen.trinkets$updateTrinketSlots();
+						}
 
 						for (AbstractClientPlayerEntity clientWorldPlayer : player.clientWorld.getPlayers()) {
 							((TrinketPlayerScreenHandler) clientWorldPlayer.playerScreenHandler).trinkets$updateTrinketSlots(true);

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -24,9 +24,9 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 	public void onInitialize() {
 		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
-		resourceManagerHelper.registerReloadListener(EntitySlotLoader.INSTANCE);
+		resourceManagerHelper.registerReloadListener(EntitySlotLoader.SERVER);
 		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success)
-				-> EntitySlotLoader.INSTANCE.sync(server.getPlayerManager().getPlayerList()));
+				-> EntitySlotLoader.SERVER.sync(server.getPlayerManager().getPlayerList()));
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -61,7 +61,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 
 	@Override
 	public void update() {
-		Map<String, SlotGroup> entitySlots = TrinketsApi.getEntitySlots(this.entity.getType());
+		Map<String, SlotGroup> entitySlots = TrinketsApi.getEntitySlots(this.entity);
 		int count = 0;
 		groups.clear();
 		Map<String, Map<String, TrinketInventory>> inventory = new HashMap<>();

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,5 +1,6 @@
 package dev.emi.trinkets.api;
 
+import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Function3;
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.TrinketsNetwork;
@@ -7,11 +8,15 @@ import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.onyxstudios.cca.api.v3.component.ComponentKey;
 import dev.onyxstudios.cca.api.v3.component.ComponentRegistryV3;
 import io.netty.buffer.Unpooled;
+import net.fabricmc.api.EnvType;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.util.TriState;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketByteBuf;
@@ -25,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import net.minecraft.world.World;
 
 public class TrinketsApi {
 	public static final ComponentKey<TrinketComponent> TRINKET_COMPONENT = ComponentRegistryV3.INSTANCE
@@ -77,18 +83,57 @@ public class TrinketsApi {
 	}
 
 	/**
+	 * @deprecated Use world-sensitive alternative {@link TrinketsApi#getPlayerSlots(World)}
 	 * @return A map of slot group names to slot groups available for players
 	 */
+	@Deprecated
 	public static Map<String, SlotGroup> getPlayerSlots() {
 		return getEntitySlots(EntityType.PLAYER);
 	}
 
 	/**
+	 * @return A sided map of slot group names to slot groups available for players
+	 */
+	public static Map<String, SlotGroup> getPlayerSlots(World world) {
+		return getEntitySlots(world, EntityType.PLAYER);
+	}
+
+	/**
+	 * @return A sided map of slot group names to slot groups available for players
+	 */
+	public static Map<String, SlotGroup> getPlayerSlots(PlayerEntity player) {
+		return getEntitySlots(player);
+	}
+
+	/**
+	 * @deprecated Use world-sensitive alternative {@link TrinketsApi#getEntitySlots(World, EntityType)}
 	 * @return A map of slot group names to slot groups available for the provided
 	 * entity type
 	 */
+	@Deprecated
 	public static Map<String, SlotGroup> getEntitySlots(EntityType<?> type) {
-		return EntitySlotLoader.INSTANCE.getEntitySlots(type);
+		EntitySlotLoader loader = FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT ? EntitySlotLoader.CLIENT : EntitySlotLoader.SERVER;
+		return loader.getEntitySlots(type);
+	}
+
+	/**
+	 * @return A sided map of slot group names to slot groups available for the provided
+	 * entity type
+	 */
+	public static Map<String, SlotGroup> getEntitySlots(World world, EntityType<?> type) {
+		EntitySlotLoader loader = world.isClient() ? EntitySlotLoader.CLIENT : EntitySlotLoader.SERVER;
+		return loader.getEntitySlots(type);
+	}
+
+	/**
+	 * @return A sided map of slot group names to slot groups available for the provided
+	 * entity
+	 */
+	public static Map<String, SlotGroup> getEntitySlots(Entity entity) {
+		if (entity != null) {
+			return getEntitySlots(entity.getWorld(), entity.getType());
+		}
+		return ImmutableMap.of();
 	}
 
 	/**

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -42,7 +42,8 @@ import net.minecraft.util.registry.Registry;
 
 public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<String, Map<String, Set<String>>>> implements IdentifiableResourceReloadListener {
 
-	public static final EntitySlotLoader INSTANCE = new EntitySlotLoader();
+	public static final EntitySlotLoader CLIENT = new EntitySlotLoader();
+	public static final EntitySlotLoader SERVER = new EntitySlotLoader();
 
 	private static final Gson GSON = (new GsonBuilder()).setPrettyPrinting().disableHtmlEscaping().create();
 	private static final Identifier ID = new Identifier(TrinketsMain.MOD_ID, "entities");

--- a/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
@@ -61,9 +61,12 @@ public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScre
 		for (int i = handler.trinkets$getTrinketSlotStart(); i < handler.trinkets$getTrinketSlotEnd(); i++) {
 			Slot slot = this.client.player.playerScreenHandler.slots.get(i);
 			if (slot instanceof SurvivalTrinketSlot ts) {
-				SlotGroup group = TrinketsApi.getPlayerSlots().get(ts.getType().getGroup());
+				SlotGroup group = TrinketsApi.getPlayerSlots(this.client.player).get(ts.getType().getGroup());
 				Rect2i rect = trinkets$getGroupRect(group);
 				Point pos = trinkets$getHandler().trinkets$getGroupPos(group);
+				if (pos == null) {
+					return;
+				}
 				int xOff = rect.getX() + 1 - pos.x();
 				int yOff = rect.getY() + 1 - pos.y();
 				((CreativeScreenHandler) this.handler).slots.add(new CreativeTrinketSlot(ts, ts.getIndex(), ts.x + xOff, ts.y + yOff));

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
@@ -2,8 +2,16 @@ package dev.emi.trinkets.mixin;
 
 
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
+import dev.emi.trinkets.TrinketsNetwork;
+import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.EntitySlotLoader;
+import java.util.Set;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,7 +29,21 @@ public abstract class PlayerManagerMixin {
 
 	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;onSpawn()V"), method = "onPlayerConnect")
 	private void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo cb) {
-		EntitySlotLoader.INSTANCE.sync(player);
+		EntitySlotLoader.SERVER.sync(player);
 		((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(false);
+		TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> {
+			PacketByteBuf buf = PacketByteBufs.create();
+			buf.writeInt(player.getId());
+			NbtCompound tag = new NbtCompound();
+			Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
+
+			for (TrinketInventory trinketInventory : inventoriesToSend) {
+				tag.put(trinketInventory.getSlotType().getGroup() + "/" + trinketInventory.getSlotType().getName(), trinketInventory.getSyncTag());
+			}
+			buf.writeNbt(tag);
+			buf.writeNbt(new NbtCompound());
+			ServerPlayNetworking.send(player, TrinketsNetwork.SYNC_INVENTORY, buf);
+			inventoriesToSend.clear();
+		});
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -1,11 +1,14 @@
 package dev.emi.trinkets.mixin;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -114,10 +117,7 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 					groupNum++;
 				}
 			}
-			if (groupNum > 4) {
-				groupCount = groupNum - 4;
-			}
-
+			groupCount = Math.max(0, groupNum - 4);
 			trinketSlotStart = slots.size();
 			slotWidths.clear();
 			slotHeights.clear();
@@ -172,27 +172,37 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 
 	@Override
 	public int trinkets$getGroupNum(SlotGroup group) {
-		return groupNums.get(group);
+		return groupNums.getOrDefault(group, 0);
 	}
-	
+
+	@Nullable
 	@Override
 	public Point trinkets$getGroupPos(SlotGroup group) {
 		return groupPos.get(group);
 	}
 
+	@Nonnull
 	@Override
 	public List<Point> trinkets$getSlotHeights(SlotGroup group) {
-		return slotHeights.get(group);
+		return slotHeights.getOrDefault(group, ImmutableList.of());
 	}
 
+	@Nullable
+	@Override
+	public Point trinkets$getSlotHeight(SlotGroup group, int i) {
+		List<Point> points = this.trinkets$getSlotHeights(group);
+		return i < points.size() ? points.get(i) : null;
+	}
+
+	@Nonnull
 	@Override
 	public List<SlotType> trinkets$getSlotTypes(SlotGroup group) {
-		return slotTypes.get(group);
+		return slotTypes.getOrDefault(group, ImmutableList.of());
 	}
 
 	@Override
 	public int trinkets$getSlotWidth(SlotGroup group) {
-		return slotWidths.get(group);
+		return slotWidths.getOrDefault(group, 0);
 	}
 
 	@Override
@@ -249,7 +259,7 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 								if (this.insertItem(stack, i, i + 1, false)) {
 									if (player.world.isClient) {
 										TrinketsClient.quickMoveTimer = 20;
-										TrinketsClient.quickMoveGroup = TrinketsApi.getPlayerSlots().get(type.getGroup());
+										TrinketsClient.quickMoveGroup = TrinketsApi.getPlayerSlots(this.owner).get(type.getGroup());
 										if (ref.index() > 0) {
 											TrinketsClient.quickMoveType = type;
 										} else {


### PR DESCRIPTION
This PR is meant to address an issue where if the slots are reloaded and the player opens the Creative inventory screen before the process is done, the game will crash with a NullPointerException.

This should close issues https://github.com/emilyploszaj/trinkets/issues/175, https://github.com/emilyploszaj/trinkets/issues/173, https://github.com/emilyploszaj/trinkets/issues/156, https://github.com/emilyploszaj/trinkets/issues/149 and supersedes PR https://github.com/emilyploszaj/trinkets/pull/195.

### The Actual Crash Part

The direct cause of the NPE, and why it only occurs in the Creative inventory screen, is because of this:
https://github.com/emilyploszaj/trinkets/blob/af941085551c0535d46ffcb405216f56809329e3/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java#L138
https://github.com/emilyploszaj/trinkets/blob/af941085551c0535d46ffcb405216f56809329e3/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java#L174-L176
The map values can be null and attempts to unbox the null object as a primitive int results in a crash.

At a very basic level, simply changing the implementation to avoid unboxing a null object is enough to address the issue and that's part of the PR. The PR also includes various additional null checks and annotations to further guard against any potential NPEs related to the maps used in the `PlayerScreenHandlerMixin`. Although the second part of this PR should avoid this problem entirely, I imagine it's better to be safe and handle null cases appropriately.

### Solving the Desync

As for the underlying issue that causes the map values to be null in the first place, `EntitySlotLoader.INSTANCE` being a singleton results in a desync in single player worlds when the slots are reloaded. The slots reload immediately but there is a lag before the client updates its stored group references, causing any access attempts to fail during the interim.

The proposed solution is to split the entity slot loader into client and server instances. The server instance is the only one that actually reloads and syncs to the client, the client only serves as an intermediary to sync with the server and then relay the slot information to other client behavior.

Since checking for the logical side necessitates a world instance (to my knowledge at least), the PR includes additional methods added to `TrinketsApi` to deprecate `getPlayerSlots` and `getEntitySlots(EntityType<?>)`. One variant takes a world and an entity type, while another variant takes an entity itself. I imagine the latter would see more use, but I added the former since there may be times when a modder wishes to access the slot information of an entity type without an actual entity instance.

### Another Small Bugfix

While testing the PR, I noticed there was a bug where the group counts for rendering slots in Trinket screens would not update properly when slots reload. The result is that the border for extra groups would not accurately reflect the correct number (but this would only ever be noticed if there were more than 4 extra groups to begin with). This PR addresses that as well with a one-line edit to how the group count is assigned in `PlayerScreenHandlerMixin`.