### PR TITLE
Fix Mod Menu dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,7 @@ dependencies {
 
 	// Dev Runtime
 	testmodImplementation sourceSets.main.output
-	modImplementation("com.terraformersmc:modmenu:${project.mod_menu_version}") {
-		transitive = false
-	}
+	modLocalRuntime "com.terraformersmc:modmenu:${project.mod_menu_version}"
 }
 
 processResources {


### PR DESCRIPTION
Devs have been running into an issue with Trinkets recently where Mod Menu is included as a dependency in Trinkets' pom. Mod Menu is marked as `transitive = false` which, instead of flagging as a non-transitive dependency like intended, flags as a transitive dependency *with none of its dependencies being transitive*. To fix this, it's changed from `modImplementation` to `modLocalRuntime`, added in Loom 0.10 specifically for this situation. A quick re-publish with this new dependency set should fix all the issues folks have been having with importing Trinkets into dev environments.