### PR TITLE
Update fr_fr.json

### DIFF
--- a/src/main/resources/assets/trinkets/lang/fr_fr.json
+++ b/src/main/resources/assets/trinkets/lang/fr_fr.json
@@ -1,9 +1,9 @@
 {
-    "trinkets.tooltip.slots.any" : "Équipable dans §9tout§r les trinket slots",
-    "trinkets.tooltip.slots.list" : "Équipable dans les trinket slots:",
-    "trinkets.tooltip.slots.single" : "Équipable dans le trinket slot %d",
+    "trinkets.tooltip.slots.any" : "Équipable dans §9tout§r les emplacements",
+    "trinkets.tooltip.slots.list" : "Équipable dans les emplacements:",
+    "trinkets.tooltip.slots.single" : "Équipable dans l'emplacement %d",
     "trinkets.tooltip.attributes.all" : "Quand équipé:",
-    "trinkets.tooltip.attributes.single" : "Quand équipé dans le trinket slot %d:",
+    "trinkets.tooltip.attributes.single" : "Quand équipé dans l'emplacement %d:",
     "trinkets.tooltip.attributes.slots" : "%d Slots",
     "trinkets.slot.head.face": "Visage",
     "trinkets.slot.head.hat": "Chapeau",


### PR DESCRIPTION
1°) It was a weird mix of french and english ( `dans les trinket slots` )

2°) I didn't change `"trinkets.tooltip.attributes.slots"` because i didn't clearly identify where that was used

3°) **LambdAurora** also suggested to use "`emplacement`" instead of a weird mix of french/english