### PR TITLE
Fix #244.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,8 @@ dependencies {
 
 	// Mod dependencies
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}")
-	modImplementation include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}")
+	modApi include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cca_version}")
+	modApi include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cca_version}")
 
 	// Dev Runtime
 	testmodImplementation sourceSets.main.output


### PR DESCRIPTION
This pull request fixes #244.

From [the CCA GitHub repository](https://github.com/OnyxStudios/Cardinal-Components-API)'s `README.md` file:

> Replace `modImplementation` with `modApi` if you expose components in your own API.
