### PR TITLE
Update for Minecraft Version 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,14 @@
 plugins {
-	id 'fabric-loom' version '1.3-SNAPSHOT'
-	id 'io.github.juuxel.loom-vineflower' version '1.11.0'
+	id 'fabric-loom' version '1.4-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
-
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
-
+base {
+	archivesName = project.archives_base_name
+}
 
 repositories {
 	maven { url = "https://maven.terraformersmc.com" }
@@ -79,6 +76,9 @@ java {
 	// if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.20.2-rc1
-yarn_mappings=1.20.2-rc1+build.2
-loader_version=0.14.22
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.1
+loader_version=0.15.1
 
-mod_version = 3.8.0
+mod_version = 3.9.0
 maven_group = dev.emi
 archives_base_name = trinkets
 
-fabric_version=0.88.5+1.20.2
-cca_version=5.3.0
-mod_menu_version=8.0.0-beta.2
+fabric_version=0.91.2+1.20.4
+cca_version=5.4.0
+mod_menu_version=9.0.0-pre.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.20.4
 yarn_mappings=1.20.4+build.1
 loader_version=0.15.1
 
-mod_version = 3.9.0
+mod_version = 3.8.0
 maven_group = dev.emi
 archives_base_name = trinkets
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -54,6 +54,6 @@
 		"fabricloader": ">=0.7.0",
 		"cardinal-components-base": ">=3.0.0-0",
 		"cardinal-components-entity": ">=3.0.0-0",
-		"fabric": ">=0.51.2"
+		"fabric-api": ">=0.51.2"
 	}
 }


### PR DESCRIPTION
This pull request updates Trinkets to work with Minecraft version 1.20.4.

CC: @emilyploszaj 

# Changelog

- Updated Loom to version 1.4 (recommended for Minecraft versions 1.20.3 and above; see [here](https://fabricmc.net/2023/11/30/1203.html)).
- Removed manual inclusion of Vineflower (included by default in Loom version 1.4; see [here](https://github.com/FabricMC/fabric-loom/releases/tag/1.4)).
- Updated `sourceCompatibility` and `targetCompatibility` to `java.sourceCompatibility` and `java.targetCompatibility`, respectively (previous functionality was deprecated; see [here](https://docs.gradle.org/8.3/userguide/upgrading_version_8.html#java_convention_deprecation)).
- Updated `archivesBaseName` to `base.archivesName` (previous functionality was deprecated; see [here](https://docs.gradle.org/8.3/userguide/upgrading_version_8.html#base_convention_deprecation)).
- Updated mod dependency from `fabric` to `fabric-api` (recommended since Minecraft version 1.19.2; see [here](https://github.com/FabricMC/fabric/pull/2446)).
- Updated to Minecraft version 1.20.4.
- Updated Yarn mappings for Minecraft version 1.20.4.
- Updated Fabric Loader to version 0.15.1.
- Updated the mod version to 3.9.0 (previous updates for Minecraft version updates seemed to use SemVer minor syntax; I can change this if you'd like).
- Updated to Fabric API version 0.91.2.
- Updated to Cardinal Components API version 5.4.0.
- Updated to Mod Menu version 9.0.0-pre.1.
