### PR TITLE
Adjust equip/unequip behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-            artifact(sourcesJar) {
+            artifact(remapSourcesJar) {
                 builtBy remapSourcesJar
             }
             afterEvaluate {


### PR DESCRIPTION
Equip/unequip now is called if stacks of the same item are changed at all, not just if items change, also smartly ignores mutation that occurs during ticking.

Fixes #217