### PR TITLE
Add `canEquipFromUse` and `getEquipSound` methods to `Trinket` interface

### DIFF
--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -9,15 +9,18 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 
 import dev.emi.trinkets.mixin.accessor.LivingEntityAccessor;
+import java.util.function.Consumer;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.Equipment;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.registry.Registries;
+import net.minecraft.sound.SoundEvent;
 import net.minecraft.util.Identifier;
 
 public interface Trinket {
@@ -26,7 +29,7 @@ public interface Trinket {
 	 * Called every tick on the client and server side
 	 *
 	 * @param stack The stack being ticked
-	 * @param slot The slot the stack is equipped to
+	 * @param slot The slot the stack is ticking in
 	 * @param entity The entity wearing the stack
 	 */
 	default void tick(ItemStack stack, SlotReference slot, LivingEntity entity) {
@@ -74,6 +77,30 @@ public interface Trinket {
 	 */
 	default boolean canUnequip(ItemStack stack, SlotReference slot, LivingEntity entity) {
 		return !EnchantmentHelper.hasBindingCurse(stack);
+	}
+
+	/**
+	 * Determines whether a trinket can automatically attempt to equip into the first available
+	 * slot when used
+	 *
+	 * @param stack The stack being equipped
+	 * @param entity The entity that is using the stack
+	 * @return Whether the stack can be equipped from use
+	 */
+	default boolean canEquipFromUse(ItemStack stack, LivingEntity entity) {
+		return false;
+	}
+
+	/**
+	 * Determines the equip sound of a trinket
+	 *
+	 * @param stack The stack for the equip sound
+	 * @param slot The slot the stack is being equipped to
+	 * @param entity The entity that is equipping the stack
+	 * @return The {@link SoundEvent} to play for equipping
+	 */
+	default SoundEvent getEquipSound(ItemStack stack, SlotReference slot, LivingEntity entity) {
+		return stack.getItem() instanceof Equipment eq ? eq.getEquipSound() : null;
 	}
 
 	/**

--- a/src/main/java/dev/emi/trinkets/api/TrinketItem.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketItem.java
@@ -3,7 +3,6 @@ package dev.emi.trinkets.api;
 import dev.emi.trinkets.TrinketSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Equipment;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundEvent;
@@ -47,7 +46,8 @@ public class TrinketItem extends Item implements Trinket {
 							if (TrinketSlot.canInsert(stack, ref, user)) {
 								ItemStack newStack = stack.copy();
 								inv.setStack(i, newStack);
-								SoundEvent soundEvent = stack.getItem() instanceof Equipment eq ? eq.getEquipSound() : null;
+								Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
+								SoundEvent soundEvent = trinket.getEquipSound(stack, ref, user);
 								if (!stack.isEmpty() && soundEvent != null) {
 								   user.emitGameEvent(GameEvent.EQUIP);
 								   user.playSound(soundEvent, 1.0F, 1.0F);


### PR DESCRIPTION
This PR aims to add two new API methods to the `Trinket` interface.

### `canEquipFromUse`

Currently, developers that want to implement "equip from use" behavior needs to implement it themselves. This is convenient to do in most cases through the `TrinketItem.equipItem` static method, which can be used from anywhere, including an item's `use` implementation. However, certain situations make this method less feasible. If a developer does not own the item, as is the case for mods that add Trinkets compatibility to vanilla/other mods, they would need to call this method from an event listener that they register themselves. In addition, mods that want to keep their Trinkets compatibility modular (i.e. multi-loader or optional dependents) will have a trickier time accommodating a static method outside of the interface.

This PR adds a `canEquipFromUse` method to the `Trinket` interface that is called from an internal `UseItemCallback` event listener. The method defaults to `false` so existing behavior won't be changed for any items. If it's overridden by an implementation to be `true`, the `TrinketItem.equipItem` method is called for the stack and subsequent processing is canceled. This precludes other use behavior on the item, but any item that already has a use behavior should not have need of this in the first place.

### `getEquipSound`

The only reference for trinket equip sounds is in `TrinketItem.equipItem`, where it defers back to the vanilla `Equipment` interface. Developers may want to provide their own equip sounds for their trinkets without the side effects of implementing the `Equipment` interface, as well as allowing different sounds based on slot or stack data. This PR adds the `getEquipSound` method to the `Trinket` interface and replaces it in the call inside `TrinketItem.equipItem`. The default for the method defers back to the `Equipment` interface as before so existing behavior should not be changed due to this.