### PR TITLE
Equip/Unequip Events; Polish of Trinket Attribute Modifiers

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketModifiers.java
+++ b/src/main/java/dev/emi/trinkets/TrinketModifiers.java
@@ -1,7 +1,11 @@
 package dev.emi.trinkets;
 
 import com.google.common.collect.Multimap;
-import dev.emi.trinkets.api.*;
+import dev.emi.trinkets.api.SlotAttributes;
+import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.Trinket;
+import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.TrinketsAttributeModifiersComponent;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
@@ -11,33 +15,27 @@ import net.minecraft.util.Identifier;
 
 public class TrinketModifiers {
 
-    //internalizes getTrinket and slotIdentifier, both which typically are generated just before the modifiers call anyway
-    public static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> get(ItemStack stack, SlotReference slot, LivingEntity entity){
-        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, slot, entity, SlotAttributes.getIdentifier(slot));
-        if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-            for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
-                if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
-                    map.put(entry.attribute(), toSlotReferencedModifier(entry.modifier(), slot));
-                }
-            }
-        }
-        return map;
-    }
+	//internalizes getTrinket and slotIdentifier, both which typically are generated just before the modifiers call anyway
+	public static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> get(ItemStack stack, SlotReference slot, LivingEntity entity){
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, slot, entity, SlotAttributes.getIdentifier(slot));
+		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
+			for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+				map.put(entry.attribute(), entry.modifier());
+			}
+		}
+		return map;
+	}
 
-    //overload if a custom method for retrieving the trinket is used. Also exposes the slotIdentifier if custom on that is needed
-    public static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> get(Trinket trinket, ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier){
-        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, slot, entity, slotIdentifier);
-        if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-            for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
-                if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
-                    map.put(entry.attribute(), toSlotReferencedModifier(entry.modifier(), slot));
-                }
-            }
-        }
-        return map;
-    }
-
-    public static EntityAttributeModifier toSlotReferencedModifier(EntityAttributeModifier modifier, SlotReference ref){
-        return new EntityAttributeModifier(modifier.id().withSuffixedPath("/" + ref.getId()), modifier.value(), modifier.operation());
-    }
+	//overload if a custom method for retrieving the trinket is used. Also exposes the slotIdentifier if custom on that is needed
+	public static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> get(Trinket trinket, ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier){
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, slot, entity, slotIdentifier);
+		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
+			for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
+					map.put(entry.attribute(), entry.modifier());
+				}
+			}
+		}
+		return map;
+	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketModifiers.java
+++ b/src/main/java/dev/emi/trinkets/TrinketModifiers.java
@@ -1,0 +1,43 @@
+package dev.emi.trinkets;
+
+import com.google.common.collect.Multimap;
+import dev.emi.trinkets.api.*;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
+
+public class TrinketModifiers {
+
+    //internalizes getTrinket and slotIdentifier, both which typically are generated just before the modifiers call anyway
+    public static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> get(ItemStack stack, SlotReference slot, LivingEntity entity){
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, slot, entity, SlotAttributes.getIdentifier(slot));
+        if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
+            for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+                if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
+                    map.put(entry.attribute(), toSlotReferencedModifier(entry.modifier(), slot));
+                }
+            }
+        }
+        return map;
+    }
+
+    //overload if a custom method for retrieving the trinket is used. Also exposes the slotIdentifier if custom on that is needed
+    public static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> get(Trinket trinket, ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier){
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, slot, entity, slotIdentifier);
+        if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
+            for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+                if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
+                    map.put(entry.attribute(), toSlotReferencedModifier(entry.modifier(), slot));
+                }
+            }
+        }
+        return map;
+    }
+
+    public static EntityAttributeModifier toSlotReferencedModifier(EntityAttributeModifier modifier, SlotReference ref){
+        return new EntityAttributeModifier(modifier.id().withSuffixedPath("/" + ref.getId()), modifier.value(), modifier.operation());
+    }
+}

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -95,7 +95,7 @@ public class TrinketsClient implements ClientModInitializer {
 			Entity e = client.world.getEntityById(payload.entityId());
 			if (e instanceof LivingEntity entity) {
 				TrinketsApi.getTrinketComponent(entity).ifPresent(comp -> {
-					var groupMap = comp.getInventory().get(payload.group());
+					Map<String, TrinketInventory> groupMap = comp.getInventory().get(payload.group());
 					if (groupMap != null) {
 						TrinketInventory inv = groupMap.get(payload.slot());
 						if (payload.index() < inv.size()) {

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -106,7 +106,31 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 						)
 					)
 				)
+				.then(
+					literal("clear")
+					.executes(context -> {
+						try {
+							return clearCommand(context);
+						} catch (Exception e){
+							e.printStackTrace();
+							return -1;
+						}
+					})
+				)
 			));
+	}
+
+	private static int clearCommand(CommandContext<ServerCommandSource> context){
+		ServerPlayerEntity player = context.getSource().getPlayer();
+		if (player != null) {
+			TrinketComponent comp = TrinketsApi.getTrinketComponent(player).get();
+			for (var entry : comp.getInventory().entrySet()){
+				for (var inv : entry.getValue().values()){
+					inv.clear();
+				}
+			}
+		}
+		return 1;
 	}
 
 	private static int trinketsCommand(CommandContext<ServerCommandSource> context, int amount) {

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -5,14 +5,7 @@ import static com.mojang.brigadier.arguments.StringArgumentType.string;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
-import dev.emi.trinkets.api.Trinket;
-import dev.emi.trinkets.api.TrinketItem;
-import dev.emi.trinkets.api.TrinketComponent;
-import dev.emi.trinkets.api.LivingEntityTrinketComponent;
-import dev.emi.trinkets.api.TrinketsApi;
-import dev.emi.trinkets.api.TrinketsAttributeModifiersComponent;
-import dev.emi.trinkets.api.SlotGroup;
-import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.*;
 import dev.emi.trinkets.payload.BreakPayload;
 import dev.emi.trinkets.payload.SyncInventoryPayload;
 import dev.emi.trinkets.payload.SyncSlotsPayload;
@@ -45,6 +38,9 @@ import net.minecraft.resource.ResourceType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.injection.struct.InjectorGroupInfo;
+
+import java.util.Map;
 
 public class TrinketsMain implements ModInitializer, EntityComponentInitializer {
 
@@ -124,8 +120,8 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 		ServerPlayerEntity player = context.getSource().getPlayer();
 		if (player != null) {
 			TrinketComponent comp = TrinketsApi.getTrinketComponent(player).get();
-			for (var entry : comp.getInventory().entrySet()){
-				for (var inv : entry.getValue().values()){
+			for (Map.Entry<String, Map<String, TrinketInventory>> entry : comp.getInventory().entrySet()){
+				for (TrinketInventory inv : entry.getValue().values()){
 					inv.clear();
 				}
 			}

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -235,9 +235,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 		this.forEach((ref, stack) -> {
 			if (!stack.isEmpty()) {
-				Identifier identifier = SlotAttributes.getIdentifier(ref);
-				Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
-				Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, ref, entity, identifier);
+				Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(stack, ref, entity);
 				for (RegistryEntry<EntityAttribute> entityAttribute : map.keySet()) {
 					if (entityAttribute.hasKeyAndValue() && entityAttribute.value() instanceof SlotAttributes.SlotEntityAttribute slotEntityAttribute) {
 						slotMap.putAll(slotEntityAttribute.slot, map.get(entityAttribute));

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
+import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.registry.RegistryWrapper;
@@ -235,7 +236,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 		this.forEach((ref, stack) -> {
 			if (!stack.isEmpty()) {
-				Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(stack, ref, entity);
+				Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
 				for (RegistryEntry<EntityAttribute> entityAttribute : map.keySet()) {
 					if (entityAttribute.hasKeyAndValue() && entityAttribute.value() instanceof SlotAttributes.SlotEntityAttribute slotEntityAttribute) {
 						slotMap.putAll(slotEntityAttribute.slot, map.get(entityAttribute));

--- a/src/main/java/dev/emi/trinkets/api/SlotAttributes.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotAttributes.java
@@ -28,10 +28,6 @@ public class SlotAttributes {
 		return CACHED_IDS.computeIfAbsent(key, Identifier::of);
 	}
 
-	public static EntityAttributeModifier toSlotReferencedModifier(EntityAttributeModifier modifier, SlotReference ref){
-		return new EntityAttributeModifier(modifier.id().withSuffixedPath("/" + ref.getId()), modifier.value(), modifier.operation());
-	}
-
 	public static class SlotEntityAttribute extends EntityAttribute {
 		public String slot;
 

--- a/src/main/java/dev/emi/trinkets/api/SlotAttributes.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotAttributes.java
@@ -13,9 +13,9 @@ import net.minecraft.util.Identifier;
 public class SlotAttributes {
 	private static final Map<String, Identifier> CACHED_IDS = Maps.newHashMap();
 	private static final Map<String, RegistryEntry<EntityAttribute>> CACHED_ATTRIBUTES = Maps.newHashMap();
-	
+
 	/**
-	 * Adds an Entity Attribute Nodifier for slot count to the provided multimap
+	 * Adds an Entity Attribute Modifier for slot count to the provided multimap
 	 */
 	public static void addSlotModifier(Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map, String slot, Identifier identifier, double amount,
 			EntityAttributeModifier.Operation operation) {
@@ -24,13 +24,16 @@ public class SlotAttributes {
 	}
 
 	public static Identifier getIdentifier(SlotReference ref) {
-		String key = ref.inventory().getSlotType().getId() + "/" + ref.index();
-		CACHED_IDS.computeIfAbsent(key, Identifier::of);
-		return CACHED_IDS.get(key);
+		String key = ref.getRefId();
+		return CACHED_IDS.computeIfAbsent(key, Identifier::of);
+	}
+
+	public static EntityAttributeModifier toSlotReferencedModifier(EntityAttributeModifier modifier, SlotReference ref){
+		return new EntityAttributeModifier(modifier.id().withSuffixedPath("/" + ref.getRefId()),modifier.value(),modifier.operation());
 	}
 
 	public static class SlotEntityAttribute extends EntityAttribute {
-		public String slot; 
+		public String slot;
 
 		private SlotEntityAttribute(String slot) {
 			super("trinkets.slot." + slot.replace("/", "."), 0);

--- a/src/main/java/dev/emi/trinkets/api/SlotAttributes.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotAttributes.java
@@ -24,12 +24,12 @@ public class SlotAttributes {
 	}
 
 	public static Identifier getIdentifier(SlotReference ref) {
-		String key = ref.getRefId();
+		String key = ref.getId();
 		return CACHED_IDS.computeIfAbsent(key, Identifier::of);
 	}
 
 	public static EntityAttributeModifier toSlotReferencedModifier(EntityAttributeModifier modifier, SlotReference ref){
-		return new EntityAttributeModifier(modifier.id().withSuffixedPath("/" + ref.getRefId()),modifier.value(),modifier.operation());
+		return new EntityAttributeModifier(modifier.id().withSuffixedPath("/" + ref.getId()), modifier.value(), modifier.operation());
 	}
 
 	public static class SlotEntityAttribute extends EntityAttribute {

--- a/src/main/java/dev/emi/trinkets/api/SlotReference.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotReference.java
@@ -1,7 +1,8 @@
 package dev.emi.trinkets.api;
 
 public record SlotReference(TrinketInventory inventory, int index) {
-    public String getRefId() {
+
+    public String getId() {
         return this.inventory.getSlotType().getId() + "/" + index;
     }
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotReference.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotReference.java
@@ -1,4 +1,7 @@
 package dev.emi.trinkets.api;
 
 public record SlotReference(TrinketInventory inventory, int index) {
+    public String getRefId() {
+        return this.inventory.getSlotType().getId() + "/" + index;
+    }
 }

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -103,32 +103,6 @@ public interface Trinket {
 		return stack.getItem() instanceof Equipment eq ? eq.getEquipSound() : null;
 	}
 
-	//internalizes getTrinket and slotIdentifier, both which typically are generated just before the modifiers call anyway
-	static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> trinketModifiers(ItemStack stack, SlotReference slot, LivingEntity entity){
-		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, slot, entity, SlotAttributes.getIdentifier(slot));
-		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-			for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
-				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
-					map.put(entry.attribute(), SlotAttributes.toSlotReferencedModifier(entry.modifier(), slot));
-				}
-			}
-		}
-		return map;
-	}
-
-	//overload if a custom method for retrieving the trinket is used. Also exposes the slotIdentifier if custom on that is needed
-	static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> trinketModifiers(Trinket trinket, ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier){
-		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, slot, entity, slotIdentifier);
-		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-			for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
-				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
-					map.put(entry.attribute(), SlotAttributes.toSlotReferencedModifier(entry.modifier(), slot));
-				}
-			}
-		}
-		return map;
-	}
-
 	/**
 	 * Returns the Entity Attribute Modifiers for a stack in a slot. Child implementations should
 	 * remain pure

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -107,7 +107,7 @@ public interface Trinket {
 	static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> trinketModifiers(ItemStack stack, SlotReference slot, LivingEntity entity){
 		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, slot, entity, SlotAttributes.getIdentifier(slot));
 		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-			for (var entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+			for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
 				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
 					map.put(entry.attribute(), SlotAttributes.toSlotReferencedModifier(entry.modifier(), slot));
 				}
@@ -120,7 +120,7 @@ public interface Trinket {
 	static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> trinketModifiers(Trinket trinket, ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier){
 		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, slot, entity, slotIdentifier);
 		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-			for (var entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+			for (TrinketsAttributeModifiersComponent. Entry entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
 				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
 					map.put(entry.attribute(), SlotAttributes.toSlotReferencedModifier(entry.modifier(), slot));
 				}

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -133,10 +133,15 @@ public interface Trinket {
 	 * Returns the Entity Attribute Modifiers for a stack in a slot. Child implementations should
 	 * remain pure
 	 * <p>
-	 * If modifiers do not change based on stack, slot, or entity, caching based on passed slotIdentifier
+	 * If modifiers do not change based on stack, slot, or entity, caching based on passed identifier
 	 * should be considered
 	 *
+	 * @param stack ItemStack being polled for modifiers
+	 * @param slot the {@link SlotReference} for the {@link TrinketInventory} the Trinket is relevant to
+	 * @param entity the LivingEntity holding the Trinket
 	 * @param slotIdentifier The Identifier to use for creating attributes
+	 * @return the Multimap with any needed entries added
+	 * @see SlotAttributes#addSlotModifier
 	 */
 	default Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier) {
 		return Multimaps.newMultimap(Maps.newLinkedHashMap(), ArrayList::new);

--- a/src/main/java/dev/emi/trinkets/api/Trinket.java
+++ b/src/main/java/dev/emi/trinkets/api/Trinket.java
@@ -103,26 +103,43 @@ public interface Trinket {
 		return stack.getItem() instanceof Equipment eq ? eq.getEquipSound() : null;
 	}
 
+	//internalizes getTrinket and slotIdentifier, both which typically are generated just before the modifiers call anyway
+	static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> trinketModifiers(ItemStack stack, SlotReference slot, LivingEntity entity){
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, slot, entity, SlotAttributes.getIdentifier(slot));
+		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
+			for (var entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
+					map.put(entry.attribute(), SlotAttributes.toSlotReferencedModifier(entry.modifier(), slot));
+				}
+			}
+		}
+		return map;
+	}
+
+	//overload if a custom method for retrieving the trinket is used. Also exposes the slotIdentifier if custom on that is needed
+	static Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> trinketModifiers(Trinket trinket, ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier){
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(stack, slot, entity, slotIdentifier);
+		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
+			for (var entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
+				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
+					map.put(entry.attribute(), SlotAttributes.toSlotReferencedModifier(entry.modifier(), slot));
+				}
+			}
+		}
+		return map;
+	}
+
 	/**
 	 * Returns the Entity Attribute Modifiers for a stack in a slot. Child implementations should
 	 * remain pure
 	 * <p>
-	 * If modifiers do not change based on stack, slot, or entity, caching based on passed UUID
+	 * If modifiers do not change based on stack, slot, or entity, caching based on passed slotIdentifier
 	 * should be considered
 	 *
 	 * @param slotIdentifier The Identifier to use for creating attributes
 	 */
 	default Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier slotIdentifier) {
-		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Multimaps.newMultimap(Maps.newLinkedHashMap(), ArrayList::new);
-
-		if (stack.contains(TrinketsAttributeModifiersComponent.TYPE)) {
-			for (var entry : stack.getOrDefault(TrinketsAttributeModifiersComponent.TYPE, TrinketsAttributeModifiersComponent.DEFAULT).modifiers()) {
-				if (entry.slot().isEmpty() || entry.slot().get().equals(slot.inventory().getSlotType().getId())) {
-					map.put(entry.attribute(), entry.modifier());
-				}
-			}
-		}
-		return map;
+		return Multimaps.newMultimap(Maps.newLinkedHashMap(), ArrayList::new);
 	}
 
 	/**

--- a/src/main/java/dev/emi/trinkets/api/TrinketItem.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketItem.java
@@ -12,11 +12,15 @@ import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.minecraft.world.event.GameEvent;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * A convenient base class for trinket items that automatically registers itself and
  */
 public class TrinketItem extends Item implements Trinket {
-	
+
 	public TrinketItem(Item.Settings settings) {
 		super(settings);
 		TrinketsApi.registerTrinket(this, this);
@@ -36,10 +40,10 @@ public class TrinketItem extends Item implements Trinket {
 	}
 
 	public static boolean equipItem(LivingEntity user, ItemStack stack) {
-		var optional = TrinketsApi.getTrinketComponent(user);
+		Optional<TrinketComponent> optional = TrinketsApi.getTrinketComponent(user);
 		if (optional.isPresent()) {
 			TrinketComponent comp = optional.get();
-			for (var group : comp.getInventory().values()) {
+			for (Map<String, TrinketInventory> group : comp.getInventory().values()) {
 				for (TrinketInventory inv : group.values()) {
 					for (int i = 0; i < inv.size(); i++) {
 						if (inv.getStack(i).isEmpty()) {

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -3,6 +3,7 @@ package dev.emi.trinkets.api;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.mojang.datafixers.util.Function3;
+import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.TrinketSlotTarget;
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.data.EntitySlotLoader;
@@ -188,7 +189,7 @@ public class TrinketsApi {
 			return TriState.DEFAULT;
 		});
 		TrinketsApi.registerTrinketPredicate(Identifier.of("trinkets", "relevant"), (stack, ref, entity) -> {
-			Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(stack, ref, entity);
+			Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
 			if (!map.isEmpty()) {
 				return TriState.TRUE;
 			}

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -1,12 +1,16 @@
 package dev.emi.trinkets.api;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
 import com.mojang.datafixers.util.Function3;
 import dev.emi.trinkets.TrinketSlotTarget;
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.data.EntitySlotLoader;
 import dev.emi.trinkets.payload.BreakPayload;
 import net.minecraft.enchantment.Enchantment;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.world.ServerWorld;
 import org.ladysnake.cca.api.v3.component.ComponentKey;
 import org.ladysnake.cca.api.v3.component.ComponentRegistryV3;
@@ -72,7 +76,7 @@ public class TrinketsApi {
 	public static void onTrinketBroken(ItemStack stack, SlotReference ref, LivingEntity entity) {
 		World world = entity.getWorld();
 		if (!world.isClient) {
-			var packet = new BreakPayload(entity.getId(), ref.inventory().getSlotType().getGroup(), ref.inventory().getSlotType().getName(), ref.index());
+			BreakPayload packet = new BreakPayload(entity.getId(), ref.inventory().getSlotType().getGroup(), ref.inventory().getSlotType().getName(), ref.index());
 			if (entity instanceof ServerPlayerEntity player) {
 				ServerPlayNetworking.send(player, packet);
 			}
@@ -150,7 +154,7 @@ public class TrinketsApi {
 	public static boolean evaluatePredicateSet(Set<Identifier> set, ItemStack stack, SlotReference ref, LivingEntity entity) {
 		TriState state = TriState.DEFAULT;
 		for (Identifier id : set) {
-			var function = getTrinketPredicate(id);
+			Optional<Function3<ItemStack, SlotReference, LivingEntity, TriState>> function = getTrinketPredicate(id);
 			if (function.isPresent()) {
 				state = function.get().apply(stack, ref, entity);
 			}
@@ -162,7 +166,7 @@ public class TrinketsApi {
 	}
 
 	public static Enchantment.Definition withTrinketSlots(Enchantment.Definition definition, Set<String> slots) {
-		var def = new Enchantment.Definition(definition.supportedItems(), definition.primaryItems(), definition.weight(), definition.maxLevel(),
+		Enchantment.Definition def = new Enchantment.Definition(definition.supportedItems(), definition.primaryItems(), definition.weight(), definition.maxLevel(),
 				definition.minCost(), definition.maxCost(), definition.anvilCost(), definition.slots());
 
 		((TrinketSlotTarget) (Object) def).trinkets$slots(slots);
@@ -184,7 +188,7 @@ public class TrinketsApi {
 			return TriState.DEFAULT;
 		});
 		TrinketsApi.registerTrinketPredicate(Identifier.of("trinkets", "relevant"), (stack, ref, entity) -> {
-			var map = Trinket.trinketModifiers(stack, ref, entity);
+			Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(stack, ref, entity);
 			if (!map.isEmpty()) {
 				return TriState.TRUE;
 			}

--- a/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsApi.java
@@ -38,7 +38,7 @@ public class TrinketsApi {
 	public static final ComponentKey<TrinketComponent> TRINKET_COMPONENT = ComponentRegistryV3.INSTANCE
 			.getOrCreate(Identifier.of(TrinketsMain.MOD_ID, "trinkets"), TrinketComponent.class);
 	private static final Map<Identifier, Function3<ItemStack, SlotReference, LivingEntity, TriState>> PREDICATES = new HashMap<>();
-	
+
 	private static final Map<Item, Trinket> TRINKETS = new HashMap<>();
 	private static final Trinket DEFAULT_TRINKET;
 
@@ -184,7 +184,7 @@ public class TrinketsApi {
 			return TriState.DEFAULT;
 		});
 		TrinketsApi.registerTrinketPredicate(Identifier.of("trinkets", "relevant"), (stack, ref, entity) -> {
-			var map = TrinketsApi.getTrinket(stack.getItem()).getModifiers(stack, ref, entity, SlotAttributes.getIdentifier(ref));
+			var map = Trinket.trinketModifiers(stack, ref, entity);
 			if (!map.isEmpty()) {
 				return TriState.TRUE;
 			}

--- a/src/main/java/dev/emi/trinkets/api/TrinketsAttributeModifiersComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketsAttributeModifiersComponent.java
@@ -68,6 +68,7 @@ public record TrinketsAttributeModifiersComponent(List<Entry> modifiers, boolean
 		public Builder add(RegistryEntry<EntityAttribute> attribute, EntityAttributeModifier modifier) {
 			return add(attribute, modifier, Optional.empty());
 		}
+
 		public Builder add(RegistryEntry<EntityAttribute> attribute, EntityAttributeModifier modifier, String slot) {
 			return add(attribute, modifier, Optional.of(slot));
 		}

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketDropCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketDropCallback.java
@@ -10,7 +10,7 @@ import net.minecraft.item.ItemStack;
 public interface TrinketDropCallback {
 	Event<TrinketDropCallback> EVENT = EventFactory.createArrayBacked(TrinketDropCallback.class,
 	listeners -> (rule, stack, ref, entity) -> {
-		for (var listener : listeners) {
+		for (TrinketDropCallback listener : listeners) {
 			rule = listener.drop(rule, stack, ref, entity);
 		}
 		return rule;

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketDropCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketDropCallback.java
@@ -9,12 +9,12 @@ import net.minecraft.item.ItemStack;
 
 public interface TrinketDropCallback {
 	Event<TrinketDropCallback> EVENT = EventFactory.createArrayBacked(TrinketDropCallback.class,
-		listeners -> (rule, stack, ref, entity) -> {
-			for (TrinketDropCallback listener : listeners) {
-				rule = listener.drop(rule, stack, ref, entity);
-			}
-			return rule;
-		});
+	listeners -> (rule, stack, ref, entity) -> {
+		for (TrinketDropCallback listener : listeners) {
+			rule = listener.drop(rule, stack, ref, entity);
+		}
+		return rule;
+	});
 
 	DropRule drop(DropRule rule, ItemStack stack, SlotReference ref, LivingEntity entity);
 }

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketDropCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketDropCallback.java
@@ -9,12 +9,12 @@ import net.minecraft.item.ItemStack;
 
 public interface TrinketDropCallback {
 	Event<TrinketDropCallback> EVENT = EventFactory.createArrayBacked(TrinketDropCallback.class,
-	listeners -> (rule, stack, ref, entity) -> {
-		for (TrinketDropCallback listener : listeners) {
-			rule = listener.drop(rule, stack, ref, entity);
-		}
-		return rule;
-	});
+		listeners -> (rule, stack, ref, entity) -> {
+			for (TrinketDropCallback listener : listeners) {
+				rule = listener.drop(rule, stack, ref, entity);
+			}
+			return rule;
+		});
 
 	DropRule drop(DropRule rule, ItemStack stack, SlotReference ref, LivingEntity entity);
 }

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
@@ -1,6 +1,7 @@
 package dev.emi.trinkets.api.event;
 
 import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.Trinket;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.LivingEntity;
@@ -8,14 +9,14 @@ import net.minecraft.item.ItemStack;
 
 public interface TrinketEquipCallback {
     Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
-    listeners -> (stack, slot, entity) -> {
-        for (TrinketEquipCallback listener: listeners){
-            listener.onEquip(stack,slot,entity);
-        }
-    });
+        listeners -> (stack, slot, entity) -> {
+            for (TrinketEquipCallback listener: listeners){
+                listener.onEquip(stack,slot,entity);
+            }
+        });
 
     /**
-     * Called when an entity equips a trinket, after the `onEquip` method of the Trinket
+     * Called when an entity equips a trinket, after the {@link Trinket#onEquip} method of the Trinket
      *
      * @param stack The stack being equipped
      * @param slot The slot the stack is equipped to

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
@@ -9,11 +9,11 @@ import net.minecraft.item.ItemStack;
 
 public interface TrinketEquipCallback {
     Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
-        listeners -> (stack, slot, entity) -> {
-            for (TrinketEquipCallback listener: listeners){
-                listener.onEquip(stack, slot, entity);
-            }
-        });
+    listeners -> (stack, slot, entity) -> {
+        for (TrinketEquipCallback listener: listeners){
+            listener.onEquip(stack, slot, entity);
+        }
+    });
 
     /**
      * Called when an entity equips a trinket, after the {@link Trinket#onEquip} method of the Trinket

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
@@ -8,19 +8,19 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 
 public interface TrinketEquipCallback {
-    Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
-    listeners -> (stack, slot, entity) -> {
-        for (TrinketEquipCallback listener: listeners){
-            listener.onEquip(stack, slot, entity);
-        }
-    });
+	Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
+	listeners -> (stack, slot, entity) -> {
+		for (TrinketEquipCallback listener: listeners){
+			listener.onEquip(stack, slot, entity);
+		}
+	});
 
-    /**
-     * Called when an entity equips a trinket, after the {@link Trinket#onEquip} method of the Trinket
-     *
-     * @param stack The stack being equipped
-     * @param slot The slot the stack is equipped to
-     * @param entity The entity that equipped the stack
-     */
-    void onEquip(ItemStack stack, SlotReference slot, LivingEntity entity);
+	/**
+	 * Called when an entity equips a trinket, after the {@link Trinket#onEquip} method of the Trinket
+	 *
+	 * @param stack The stack being equipped
+	 * @param slot The slot the stack is equipped to
+	 * @param entity The entity that equipped the stack
+	 */
+	void onEquip(ItemStack stack, SlotReference slot, LivingEntity entity);
 }

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
@@ -11,7 +11,7 @@ public interface TrinketEquipCallback {
     Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
         listeners -> (stack, slot, entity) -> {
             for (TrinketEquipCallback listener: listeners){
-                listener.onEquip(stack,slot,entity);
+                listener.onEquip(stack, slot, entity);
             }
         });
 

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
@@ -9,7 +9,7 @@ import net.minecraft.item.ItemStack;
 public interface TrinketEquipCallback {
     Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
     listeners -> (stack, slot, entity) -> {
-        for (var listener: listeners){
+        for (TrinketEquipCallback listener: listeners){
             listener.onEquip(stack,slot,entity);
         }
     });

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketEquipCallback.java
@@ -1,0 +1,25 @@
+package dev.emi.trinkets.api.event;
+
+import dev.emi.trinkets.api.SlotReference;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+
+public interface TrinketEquipCallback {
+    Event<TrinketEquipCallback> EVENT = EventFactory.createArrayBacked(TrinketEquipCallback.class,
+    listeners -> (stack, slot, entity) -> {
+        for (var listener: listeners){
+            listener.onEquip(stack,slot,entity);
+        }
+    });
+
+    /**
+     * Called when an entity equips a trinket, after the `onEquip` method of the Trinket
+     *
+     * @param stack The stack being equipped
+     * @param slot The slot the stack is equipped to
+     * @param entity The entity that equipped the stack
+     */
+    void onEquip(ItemStack stack, SlotReference slot, LivingEntity entity);
+}

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
@@ -1,0 +1,25 @@
+package dev.emi.trinkets.api.event;
+
+import dev.emi.trinkets.api.SlotReference;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+
+public interface TrinketUnequipCallback {
+    Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
+    listeners -> (stack, slot, entity) -> {
+        for (var listener: listeners){
+            listener.onUnequip(stack,slot,entity);
+        }
+    });
+
+    /**
+     * Called when an entity un-equips a trinket, after the `onUnequip` method of the Trinket
+     *
+     * @param stack The stack being unequipped
+     * @param slot The slot the stack was unequipped from
+     * @param entity The entity that unequipped the stack
+     */
+    void onUnequip(ItemStack stack, SlotReference slot, LivingEntity entity);
+}

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
@@ -9,7 +9,7 @@ import net.minecraft.item.ItemStack;
 public interface TrinketUnequipCallback {
     Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
     listeners -> (stack, slot, entity) -> {
-        for (var listener: listeners){
+        for (TrinketUnequipCallback listener: listeners){
             listener.onUnequip(stack,slot,entity);
         }
     });

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
@@ -11,7 +11,7 @@ public interface TrinketUnequipCallback {
     Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
         listeners -> (stack, slot, entity) -> {
             for (TrinketUnequipCallback listener: listeners){
-                listener.onUnequip(stack,slot,entity);
+                listener.onUnequip(stack, slot, entity);
             }
         });
 

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
@@ -1,6 +1,7 @@
 package dev.emi.trinkets.api.event;
 
 import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.Trinket;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.LivingEntity;
@@ -8,14 +9,14 @@ import net.minecraft.item.ItemStack;
 
 public interface TrinketUnequipCallback {
     Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
-    listeners -> (stack, slot, entity) -> {
-        for (TrinketUnequipCallback listener: listeners){
-            listener.onUnequip(stack,slot,entity);
-        }
-    });
+        listeners -> (stack, slot, entity) -> {
+            for (TrinketUnequipCallback listener: listeners){
+                listener.onUnequip(stack,slot,entity);
+            }
+        });
 
     /**
-     * Called when an entity un-equips a trinket, after the `onUnequip` method of the Trinket
+     * Called when an entity un-equips a trinket, after the {@link Trinket#onUnequip} method of the Trinket
      *
      * @param stack The stack being unequipped
      * @param slot The slot the stack was unequipped from

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
@@ -8,19 +8,19 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
 
 public interface TrinketUnequipCallback {
-    Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
-    listeners -> (stack, slot, entity) -> {
-        for (TrinketUnequipCallback listener: listeners){
-            listener.onUnequip(stack, slot, entity);
-        }
-    });
+	Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
+	listeners -> (stack, slot, entity) -> {
+		for (TrinketUnequipCallback listener: listeners){
+			listener.onUnequip(stack, slot, entity);
+		}
+	});
 
-    /**
-     * Called when an entity un-equips a trinket, after the {@link Trinket#onUnequip} method of the Trinket
-     *
-     * @param stack The stack being unequipped
-     * @param slot The slot the stack was unequipped from
-     * @param entity The entity that unequipped the stack
-     */
-    void onUnequip(ItemStack stack, SlotReference slot, LivingEntity entity);
+	/**
+	 * Called when an entity un-equips a trinket, after the {@link Trinket#onUnequip} method of the Trinket
+	 *
+	 * @param stack The stack being unequipped
+	 * @param slot The slot the stack was unequipped from
+	 * @param entity The entity that unequipped the stack
+	 */
+	void onUnequip(ItemStack stack, SlotReference slot, LivingEntity entity);
 }

--- a/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/TrinketUnequipCallback.java
@@ -9,11 +9,11 @@ import net.minecraft.item.ItemStack;
 
 public interface TrinketUnequipCallback {
     Event<TrinketUnequipCallback> EVENT = EventFactory.createArrayBacked(TrinketUnequipCallback.class,
-        listeners -> (stack, slot, entity) -> {
-            for (TrinketUnequipCallback listener: listeners){
-                listener.onUnequip(stack, slot, entity);
-            }
-        });
+    listeners -> (stack, slot, entity) -> {
+        for (TrinketUnequipCallback listener: listeners){
+            listener.onUnequip(stack, slot, entity);
+        }
+    });
 
     /**
      * Called when an entity un-equips a trinket, after the {@link Trinket#onUnequip} method of the Trinket

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -200,7 +200,7 @@ public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<Stri
 	}
 
 	public void sync(List<? extends ServerPlayerEntity> players) {
-		var packet = new SyncSlotsPayload(Map.copyOf(this.slots));
+		SyncSlotsPayload packet = new SyncSlotsPayload(Map.copyOf(this.slots));
 		players.forEach(player -> ServerPlayNetworking.send(player, packet));
 		players.forEach(player -> ((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(true));
 	}

--- a/src/main/java/dev/emi/trinkets/mixin/EnchantmentHelperMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/EnchantmentHelperMixin.java
@@ -54,7 +54,7 @@ public abstract class EnchantmentHelperMixin {
 							Set<String> trinketSlots = ((TrinketSlotTarget) (Object) registryEntry.value().definition()).trinkets$slots();
 
 							if (slots.contains(AttributeModifierSlot.ANY) || slots.contains(AttributeModifierSlot.ARMOR) || trinketSlots.contains(ref.inventory().getSlotType().getId())) {
-								contextAwareConsumer.accept(registryEntry, entry.getIntValue(),context);
+								contextAwareConsumer.accept(registryEntry, entry.getIntValue(), context);
 							}
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/ItemStackMixin.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.llamalad7.mixinextras.sugar.Local;
+import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.TrinketSlot;
 import dev.emi.trinkets.api.SlotAttributes;
 import dev.emi.trinkets.api.SlotReference;
@@ -87,7 +88,7 @@ public abstract class ItemStackMixin {
 							if (!sameTranslationExists) {
 								slots.add(slotType);
 							}
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(self, ref, player);
+							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(self, ref, player);
 
 							if (defaultModifier == null) {
 								defaultModifier = map;

--- a/src/main/java/dev/emi/trinkets/mixin/ItemStackMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/ItemStackMixin.java
@@ -53,13 +53,14 @@ public abstract class ItemStackMixin {
 
 			boolean hideAdditionalTooltip = self.contains(DataComponentTypes.HIDE_ADDITIONAL_TOOLTIP);
 			boolean showAttributeTooltip = self.getOrDefault(DataComponentTypes.ATTRIBUTE_MODIFIERS, AttributeModifiersComponent.DEFAULT).showInTooltip();
-			if (hideAdditionalTooltip && !showAttributeTooltip)
-				//literally nothing to do
+			if (hideAdditionalTooltip && !showAttributeTooltip) {
+				// nothing to do
 				return;
+			}
 
 			boolean canEquipAnywhere = true;
 			Set<SlotType> slots = Sets.newHashSet();
-			Map<MutableText, Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier>> modifiers = Maps.newHashMap();
+			Map<SlotType, Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier>> modifiers = Maps.newHashMap();
 			Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> defaultModifier = null;
 			boolean allModifiersSame = true;
 			int slotCount = 0;
@@ -95,8 +96,8 @@ public abstract class ItemStackMixin {
 							}
 
 							boolean duplicate = false;
-							for (Map.Entry<MutableText, Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier>> entry : modifiers.entrySet()) {
-								if (entry.getKey().getString().equals(slotType.getTranslation().getString())) {
+							for (Map.Entry<SlotType, Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier>> entry : modifiers.entrySet()) {
+								if (entry.getKey().getTranslation().getString().equals(slotType.getTranslation().getString())) {
 									if (areMapsEqual(entry.getValue(), map)) {
 										duplicate = true;
 										break;
@@ -105,7 +106,7 @@ public abstract class ItemStackMixin {
 							}
 
 							if (!duplicate) {
-								modifiers.put(slotType.getTranslation(), map);
+								modifiers.put(slotType, map);
 							}
 							continue outer;
 						} else if (canInsert) {
@@ -142,9 +143,9 @@ public abstract class ItemStackMixin {
 						addAttributes(list, defaultModifier);
 					}
 				} else {
-					for (Map.Entry<MutableText, Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier>> entry : modifiers.entrySet()) {
+					for (Map.Entry<SlotType, Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier>> entry : modifiers.entrySet()) {
 						list.add(Text.translatable("trinkets.tooltip.attributes.single",
-								entry.getKey().formatted(Formatting.BLUE)).formatted(Formatting.GRAY));
+								entry.getKey().getTranslation().formatted(Formatting.BLUE)).formatted(Formatting.GRAY));
 						addAttributes(list, entry.getValue());
 					}
 				}

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -68,8 +68,8 @@ public abstract class LivingEntityMixin extends Entity {
 	@Shadow
 	public abstract AttributeContainer getAttributes();
 
-	private LivingEntityMixin(EntityType<?> type, World world) {
-		super(type, world);
+	private LivingEntityMixin() {
+		super(null, null);
 	}
 
 	@Inject(at = @At("HEAD"), method = "canFreeze", cancellable = true)
@@ -134,7 +134,6 @@ public abstract class LivingEntityMixin extends Entity {
 	private void dropFromEntity(ItemStack stack) {
 		ItemEntity entity = dropStack(stack);
 		// Mimic player drop behavior for only players
-        //noinspection ConstantValue
         if (entity != null && ((Entity) this) instanceof PlayerEntity) {
 			entity.setPos(entity.getX(), this.getEyeY() - 0.3, entity.getZ());
 			entity.setPickupDelay(40);

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -16,6 +16,8 @@ import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketComponent;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.event.TrinketEquipCallback;
+import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import dev.emi.trinkets.payload.SyncInventoryPayload;
 import net.minecraft.component.EnchantmentEffectComponentTypes;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
@@ -62,12 +64,12 @@ import net.minecraft.world.World;
 public abstract class LivingEntityMixin extends Entity {
 	@Unique
 	private final Map<String, ItemStack> lastEquippedTrinkets = new HashMap<>();
-	
-	@Shadow
-	protected abstract AttributeContainer getAttributes();
 
-	private LivingEntityMixin() {
-		super(null, null);
+	@Shadow
+	public abstract AttributeContainer getAttributes();
+
+	private LivingEntityMixin(EntityType<?> type, World world) {
+		super(type, world);
 	}
 
 	@Inject(at = @At("HEAD"), method = "canFreeze", cancellable = true)
@@ -96,7 +98,7 @@ public abstract class LivingEntityMixin extends Entity {
 			DropRule dropRule = TrinketsApi.getTrinket(stack.getItem()).getDropRule(stack, ref, entity);
 
 			dropRule = TrinketDropCallback.EVENT.invoker().drop(dropRule, stack, ref, entity);
-			
+
 			TrinketInventory inventory = ref.inventory();
 
 			if (dropRule == DropRule.DEFAULT) {
@@ -128,10 +130,12 @@ public abstract class LivingEntityMixin extends Entity {
 		}));
 	}
 
+	@Unique
 	private void dropFromEntity(ItemStack stack) {
 		ItemEntity entity = dropStack(stack);
 		// Mimic player drop behavior for only players
-		if (entity != null && ((Entity) this) instanceof PlayerEntity) {
+        //noinspection ConstantValue
+        if (entity != null && ((Entity) this) instanceof PlayerEntity) {
 			entity.setPos(entity.getX(), this.getEyeY() - 0.3, entity.getZ());
 			entity.setPickupDelay(40);
 			float magnitude = this.random.nextFloat() * 0.5f;
@@ -161,16 +165,16 @@ public abstract class LivingEntityMixin extends Entity {
 				if (!ItemStack.areEqual(newStack, oldStack)) {
 
 					TrinketsApi.getTrinket(oldStack.getItem()).onUnequip(oldStack, ref, entity);
+					TrinketUnequipCallback.EVENT.invoker().onUnequip(oldStack, ref, entity);
 					TrinketsApi.getTrinket(newStack.getItem()).onEquip(newStack, ref, entity);
+					TrinketEquipCallback.EVENT.invoker().onEquip(newStack, ref, entity);
 
 					World world = this.getWorld();
 					if (!world.isClient) {
 						contentUpdates.put(newRef, newStackCopy);
-						Identifier identifier = SlotAttributes.getIdentifier(ref);
 
 						if (!oldStack.isEmpty()) {
-							Trinket trinket = TrinketsApi.getTrinket(oldStack.getItem());
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(oldStack, ref, entity, identifier);
+							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(oldStack, ref, entity);
 							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 							Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
 							for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
@@ -194,8 +198,7 @@ public abstract class LivingEntityMixin extends Entity {
 						}
 
 						if (!newStack.isEmpty()) {
-							Trinket trinket = TrinketsApi.getTrinket(newStack.getItem());
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = trinket.getModifiers(newStack, ref, entity, identifier);
+							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(newStack, ref, entity);
 							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 							Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
 							for (RegistryEntry<EntityAttribute> attr : map.keySet()) {

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -9,6 +9,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
+import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.api.SlotAttributes;
 import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.SlotType;
@@ -173,7 +174,7 @@ public abstract class LivingEntityMixin extends Entity {
 						contentUpdates.put(newRef, newStackCopy);
 
 						if (!oldStack.isEmpty()) {
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(oldStack, ref, entity);
+							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(oldStack, ref, entity);
 							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 							Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
 							for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
@@ -197,7 +198,7 @@ public abstract class LivingEntityMixin extends Entity {
 						}
 
 						if (!newStack.isEmpty()) {
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = Trinket.trinketModifiers(newStack, ref, entity);
+							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(newStack, ref, entity);
 							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 							Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
 							for (RegistryEntry<EntityAttribute> attr : map.keySet()) {

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
@@ -35,7 +35,7 @@ public abstract class PlayerManagerMixin {
 		EntitySlotLoader.SERVER.sync(player);
 		((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(false);
 		TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> {
-			var tag = new HashMap<String, NbtCompound>();
+			Map<String, NbtCompound> tag = new HashMap<>();
 			Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
 
 			for (TrinketInventory trinketInventory : inventoriesToSend) {

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerScreenHandlerMixin.java
@@ -79,7 +79,9 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 	@Override
 	public void trinkets$updateTrinketSlots(boolean slotsChanged) {
 		TrinketsApi.getTrinketComponent(owner).ifPresent(trinkets -> {
-			if (slotsChanged) trinkets.update();
+			if (slotsChanged) {
+				trinkets.update();
+			}
 			Map<String, SlotGroup> groups = trinkets.getGroups();
 			groupPos.clear();
 			while (trinketSlotStart < trinketSlotEnd) {
@@ -250,7 +252,7 @@ public abstract class PlayerScreenHandlerMixin extends ScreenHandler implements 
 							if (!(s instanceof SurvivalTrinketSlot) || !s.canInsert(stack)) {
 								continue;
 							}
-							
+
 							SurvivalTrinketSlot ts = (SurvivalTrinketSlot) s;
 							SlotType type = ts.getType();
 							SlotReference ref = new SlotReference((TrinketInventory) ts.inventory, ts.getIndex());

--- a/src/main/java/dev/emi/trinkets/payload/SyncSlotsPayload.java
+++ b/src/main/java/dev/emi/trinkets/payload/SyncSlotsPayload.java
@@ -18,7 +18,7 @@ public record SyncSlotsPayload(Map<EntityType<?>, Map<String, SlotGroup>> map) i
 			(x) -> (Map<EntityType<?>, Map<String, SlotGroup>>) new HashMap<EntityType<?>, Map<String, SlotGroup>>(x),
 			PacketCodecs.registryValue(RegistryKeys.ENTITY_TYPE),
 			PacketCodecs.map(HashMap::new, PacketCodecs.STRING, PacketCodecs.NBT_COMPOUND.xmap(SlotGroup::read, (x) -> {
-				var nbt = new NbtCompound();
+				NbtCompound nbt = new NbtCompound();
 				x.write(nbt);
 				return nbt;
 			}))

--- a/src/testmod/java/dev/emi/trinkets/TestTrinket2.java
+++ b/src/testmod/java/dev/emi/trinkets/TestTrinket2.java
@@ -34,9 +34,9 @@ public class TestTrinket2 extends TrinketItem {
 
 	@Override
 	public Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier id) {
-		/*//testing the composition of the new attribute suffix
-		TrinketsTest.LOGGER.info(SlotAttributes.toSlotReferencedModifier(new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
-				0.4, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), slot));*/
+		// un-comment to check - testing the composition of the new attribute suffix
+		// TrinketsTest.LOGGER.info(TrinketModifiers.toSlotReferencedModifier(new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
+		//		0.4, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), slot));
 		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> modifiers = Multimaps.newMultimap(Maps.newLinkedHashMap(), ArrayList::new);
 		EntityAttributeModifier speedModifier = new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
 				0.1, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL);

--- a/src/testmod/java/dev/emi/trinkets/TestTrinket2.java
+++ b/src/testmod/java/dev/emi/trinkets/TestTrinket2.java
@@ -1,0 +1,46 @@
+package dev.emi.trinkets;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import dev.emi.trinkets.api.SlotAttributes;
+import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.TrinketItem;
+import dev.emi.trinkets.api.client.TrinketRenderer;
+import dev.emi.trinkets.client.TrinketModel;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.render.OverlayTexture;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.model.BipedEntityModel;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.util.Identifier;
+
+import java.util.ArrayList;
+
+public class TestTrinket2 extends TrinketItem {
+
+	public TestTrinket2(Settings settings) {
+		super(settings);
+	}
+
+	@Override
+	public Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier id) {
+		/*//testing the composition of the new attribute suffix
+		TrinketsTest.LOGGER.info(SlotAttributes.toSlotReferencedModifier(new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
+				0.4, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),slot));*/
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> modifiers = Multimaps.newMultimap(Maps.newLinkedHashMap(), ArrayList::new);
+		EntityAttributeModifier speedModifier = new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
+				0.1, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL);
+		modifiers.put(EntityAttributes.GENERIC_MOVEMENT_SPEED, speedModifier);
+		return modifiers;
+	}
+}

--- a/src/testmod/java/dev/emi/trinkets/TestTrinket2.java
+++ b/src/testmod/java/dev/emi/trinkets/TestTrinket2.java
@@ -36,7 +36,7 @@ public class TestTrinket2 extends TrinketItem {
 	public Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> getModifiers(ItemStack stack, SlotReference slot, LivingEntity entity, Identifier id) {
 		/*//testing the composition of the new attribute suffix
 		TrinketsTest.LOGGER.info(SlotAttributes.toSlotReferencedModifier(new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
-				0.4, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL),slot));*/
+				0.4, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL), slot));*/
 		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> modifiers = Multimaps.newMultimap(Maps.newLinkedHashMap(), ArrayList::new);
 		EntityAttributeModifier speedModifier = new EntityAttributeModifier(id.withSuffixedPath("trinkets-testmod/movement_speed"),
 				0.1, EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL);

--- a/src/testmod/java/dev/emi/trinkets/TrinketsTest.java
+++ b/src/testmod/java/dev/emi/trinkets/TrinketsTest.java
@@ -1,9 +1,13 @@
 package dev.emi.trinkets;
 
+import dev.emi.trinkets.api.event.TrinketEquipCallback;
+import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import net.fabricmc.api.ModInitializer;
 import net.minecraft.item.Item;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Identifier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,11 +17,23 @@ public class TrinketsTest implements ModInitializer {
 	public static final String MOD_ID = "trinkets-testmod";
 	public static final Logger LOGGER = LogManager.getLogger();
 	public static Item TEST_TRINKET;
+	public static Item TEST_TRINKET_2;
 
 	@Override
 	public void onInitialize() {
 		LOGGER.info("[Trinkets Testmod] test mod was initialized!");
 		TEST_TRINKET = Registry.register(Registries.ITEM, identifier("test"), new TestTrinket(new Item.Settings().maxCount(1).maxDamage(100)));
+		TEST_TRINKET_2 = Registry.register(Registries.ITEM, identifier("test2"), new TestTrinket2(new Item.Settings().maxCount(1)));
+		TrinketEquipCallback.EVENT.register(((stack, slot, entity) -> {
+			if(stack.isOf(TEST_TRINKET_2)){
+				entity.getWorld().playSound(null,entity.getBlockPos(), SoundEvents.ENTITY_ARROW_HIT, SoundCategory.PLAYERS, 1f,1f);
+			}
+		}));
+		TrinketUnequipCallback.EVENT.register(((stack, slot, entity) -> {
+			if(stack.isOf(TEST_TRINKET_2)){
+				entity.getWorld().playSound(null,entity.getBlockPos(), SoundEvents.ITEM_TRIDENT_THUNDER.value(), SoundCategory.PLAYERS, 0.5f,1f);
+			}
+		}));
 	}
 
 	private static Identifier identifier(String id) {

--- a/src/testmod/java/dev/emi/trinkets/TrinketsTest.java
+++ b/src/testmod/java/dev/emi/trinkets/TrinketsTest.java
@@ -26,12 +26,12 @@ public class TrinketsTest implements ModInitializer {
 		TEST_TRINKET_2 = Registry.register(Registries.ITEM, identifier("test2"), new TestTrinket2(new Item.Settings().maxCount(1)));
 		TrinketEquipCallback.EVENT.register(((stack, slot, entity) -> {
 			if(stack.isOf(TEST_TRINKET_2)){
-				entity.getWorld().playSound(null,entity.getBlockPos(), SoundEvents.ENTITY_ARROW_HIT, SoundCategory.PLAYERS, 1f,1f);
+				entity.getWorld().playSound(null, entity.getBlockPos(), SoundEvents.ENTITY_ARROW_HIT, SoundCategory.PLAYERS, 1f, 1f);
 			}
 		}));
 		TrinketUnequipCallback.EVENT.register(((stack, slot, entity) -> {
 			if(stack.isOf(TEST_TRINKET_2)){
-				entity.getWorld().playSound(null,entity.getBlockPos(), SoundEvents.ITEM_TRIDENT_THUNDER.value(), SoundCategory.PLAYERS, 0.5f,1f);
+				entity.getWorld().playSound(null, entity.getBlockPos(), SoundEvents.ITEM_TRIDENT_THUNDER.value(), SoundCategory.PLAYERS, 0.5f, 1f);
 			}
 		}));
 	}

--- a/src/testmod/resources/assets/trinkets-testmod/lang/en_us.json
+++ b/src/testmod/resources/assets/trinkets-testmod/lang/en_us.json
@@ -1,3 +1,4 @@
 {
-  "item.trinkets-testmod.test": "Test Trinket"
+  "item.trinkets-testmod.test": "Test Trinket",
+  "item.trinkets-testmod.test2": "Test Trinket 2"
 }

--- a/src/testmod/resources/assets/trinkets-testmod/models/item/test2.json
+++ b/src/testmod/resources/assets/trinkets-testmod/models/item/test2.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:item/nether_star"
+}

--- a/src/testmod/resources/data/trinkets/tags/item/hand/ring.json
+++ b/src/testmod/resources/data/trinkets/tags/item/hand/ring.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trinkets-testmod:test2"
+  ]
+}

--- a/src/testmod/resources/data/trinkets/tags/item/offhand/ring.json
+++ b/src/testmod/resources/data/trinkets/tags/item/offhand/ring.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "trinkets-testmod:test2"
+  ]
+}


### PR DESCRIPTION
## Resolves:
* https://github.com/emilyploszaj/trinkets/issues/309
* https://github.com/emilyploszaj/trinkets/issues/289
* Trinkets with multiple "same" slots (hand/ring, offhand/ring) still showing multiple repeating attribute blocks
* Trinket slots with multiple slots having modifier collisions

## Explanation
👍 Added new `TrinketEquipCallback` and `TrinketUnequipCallback`. Each have the same parameters as the `Trinket` method itself. They are wired in the same spot as the Trinket method, directly after the trinkets method is called. Added simple test registrations for them; both working.

👍Added new method `getRefId()` to SlotReference; tucking away the messy inventory().slotType().getId() etc etc.

👍Used this new method in a new method in `SlotAttributes`; `toSlotReferencedModifier`. This method suffixes the modifier with the `getRefId()`. This avoids collisions if multiple slots are available for one "slot", or if trinkets could go into multiple/any slot, and attributes are being added via NBT. Previously the identifier added via NBT would be used directly; causing conflicts if 2+ of the same NBT trinket are equipped.

👍Incorporated this new method into a new static method in `Trinket`; `trinketModifiers`. This flips the script on the previous `Build NBT Attributes -> Hope the user calls super -> return map`. Now the flow is `Provide blank multimap if the user calls super -> user adds code-side modifiers -> Trinket adds NBT modifiers -> return map`. This flow is tested in the new TestTrinket2, which does NOT call super, and yet both modifiers are still apparent (presuming you `/give` yourself a TestTrinket2 with some NBT modifiers).
![image](https://github.com/emilyploszaj/trinkets/assets/72876796/9769383d-cc89-4a62-8557-a42ec48f37a6)

Also encapsulates `getTrinket` and `SlotAttributes.getIdentifier`, as at every Trinkets call site those were simply generated immediately before passing them in. Now they are just generated in situ, with an overload available to be custom if needed.

Technically a implementation change in the off chance that someone was relying on finding an NBT attribute to determine if they do anything attribute related in code (despite your insistence in the docs to keep the contract pure). Unsure the impact compared to people just not calling super (definitely happens). Understandable if you want to flip this logic back, with the other improvements intact.

👍Wired the new `trinketModifiers` method into all the Trinkets call sites.

👍Polished `ItemStackMixin`: 
* Tooltip hiding is checked up front and short circuits the method if all relevant trinket tooltips are hidden anyways.
* Fixed "same" slots still being shown separately. Easy exmaple `hand/ring` and `offhand/ring`. Reason this was still happening: Equality of `SlotType` was checked with the translation, but the relevant maps were then stored with the `SlotType` as the key, undoing this check. Map now uses the `MutableText` that was checked as the key directly. Results:

Before:
![image](https://github.com/emilyploszaj/trinkets/assets/72876796/ecfb7f73-8a3d-4d1b-96f4-933064609c48)

After (Test Trinket 2 is equippable in both ring slots):
![image](https://github.com/emilyploszaj/trinkets/assets/72876796/a965bd2f-8a18-41e9-a047-e1e5fda816ed)

👍Added `clear` argument to the trinkets command (`/trinkets clear`). This clears out all of the trinket slots.

## Could Do
Could add `canEquip` and `canUnequip` callbacks to have Event functionality for those main 4 trinket methods. I stopped at `onEquip` and `onUnequip` because that was the asked content in the issue, and custom predicates can be made. 

## Recommend
Adding info about the two new events to the Wiki