### PR TITLE
Update to 1.21.7 (compatible with 1.21.6)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
-loader_version=0.16.10
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
+loader_version=0.16.14
 
 mod_version = 3.11.0
 maven_group = dev.emi
 archives_base_name = trinkets
 
-fabric_version=0.119.5+1.21.5
-cca_version=6.3.0
-mod_menu_version=14.0.0-rc.2
+fabric_version=0.127.0+1.21.6
+cca_version=7.0.0-beta.1
+mod_menu_version=15.0.0-beta.2
 emi_version=1.1.16+1.21.1
 rei_version=18.0.796
 cloth_config_version=17.0.144

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.7
+yarn_mappings=1.21.7+build.1
 loader_version=0.16.14
 
 mod_version = 3.11.0
 maven_group = dev.emi
 archives_base_name = trinkets
 
-fabric_version=0.127.0+1.21.6
+fabric_version=0.128.2+1.21.7
 cca_version=7.0.0-beta.1
 mod_menu_version=15.0.0-beta.2
 emi_version=1.1.16+1.21.1

--- a/src/main/java/dev/emi/trinkets/CreativeTrinketScreen.java
+++ b/src/main/java/dev/emi/trinkets/CreativeTrinketScreen.java
@@ -1,0 +1,7 @@
+package dev.emi.trinkets;
+
+import net.minecraft.client.gui.DrawContext;
+
+public interface CreativeTrinketScreen {
+    void trinkets$renderCreative(DrawContext context, int mouseX, int mouseY, float deltaTicks);
+}

--- a/src/main/java/dev/emi/trinkets/CreativeTrinketSlot.java
+++ b/src/main/java/dev/emi/trinkets/CreativeTrinketSlot.java
@@ -21,6 +21,11 @@ public class CreativeTrinketSlot extends CreativeSlot implements TrinketSlot {
 	}
 
 	@Override
+	public boolean renderAfterRegularSlots() {
+		return original.renderAfterRegularSlots();
+	}
+
+	@Override
 	public Identifier getBackgroundIdentifier() {
 		return original.getBackgroundIdentifier();
 	}

--- a/src/main/java/dev/emi/trinkets/SurvivalTrinketSlot.java
+++ b/src/main/java/dev/emi/trinkets/SurvivalTrinketSlot.java
@@ -78,6 +78,11 @@ public class SurvivalTrinketSlot extends Slot implements TrinketSlot {
 	}
 
 	@Override
+	public boolean renderAfterRegularSlots() {
+		return slotOffset != 0 || !this.alwaysVisible;
+	}
+
+	@Override
 	public Identifier getBackgroundIdentifier() {
 		return type.getIcon();
 	}

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -3,14 +3,12 @@ package dev.emi.trinkets;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
-import com.mojang.blaze3d.opengl.GlStateManager;
-
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.TrinketsApi;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.util.math.Rect2i;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.Identifier;
@@ -200,10 +198,7 @@ public class TrinketScreenManager {
 		}
 
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
-		GlStateManager._enableDepthTest();
-		context.getMatrices().push();
-		context.getMatrices().translate(0, 0, 305);
-
+		context.getMatrices().pushMatrix();
 		Rect2i r = currentScreen.trinkets$getGroupRect(group);
 		int slotsWidth = handler.trinkets$getSlotWidth(group) + 1;
 		List<Point> slotHeights = handler.trinkets$getSlotHeights(group);
@@ -270,12 +265,11 @@ public class TrinketScreenManager {
 			drawTexture(context, MORE_SLOTS, x + 4, y + 4, 4, 4, 18, 18);
 		}
 
-		context.getMatrices().pop();
-		GlStateManager._disableDepthTest();
+		context.getMatrices().popMatrix();
 	}
 
 	private static void drawTexture(DrawContext context, Identifier texture, int x, int y, int u, int v, int width, int height) {
-		context.drawTexture(RenderLayer::getGuiTextured, texture,  x, y, u, v, width, height, 256, 256);
+		context.drawTexture(RenderPipelines.GUI_TEXTURED, texture,  x, y, u, v, width, height, 256, 256);
 	}
 
 	public static void drawActiveGroup(DrawContext context) {

--- a/src/main/java/dev/emi/trinkets/TrinketSlot.java
+++ b/src/main/java/dev/emi/trinkets/TrinketSlot.java
@@ -11,10 +11,12 @@ public interface TrinketSlot {
 
 	public boolean isTrinketFocused();
 
+	public boolean renderAfterRegularSlots();
+
 	public Identifier getBackgroundIdentifier();
 
 	public SlotType getType();
-	
+
 	public static boolean canInsert(ItemStack stack, SlotReference slotRef, LivingEntity entity) {
 		boolean res = TrinketsApi.evaluatePredicateSet(slotRef.inventory().getSlotType().getValidatorPredicates(),
 			stack, slotRef, entity);

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -4,6 +4,7 @@ import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketSaveData;
 import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.data.EntitySlotLoader;
@@ -16,7 +17,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 
 import java.util.Map;
 
@@ -34,7 +34,7 @@ public class TrinketsClient implements ClientModInitializer {
 			Entity entity = client.world.getEntityById(payload.entityId());
 			if (entity instanceof LivingEntity) {
 				TrinketsApi.getTrinketComponent((LivingEntity) entity).ifPresent(trinkets -> {
-					for (Map.Entry<String, NbtCompound> entry : payload.inventoryUpdates().entrySet()) {
+					for (Map.Entry<String, TrinketSaveData.Metadata> entry : payload.inventoryUpdates().entrySet()) {
 						String[] split = entry.getKey().split("/");
 						String group = split[0];
 						String slot = split[1];
@@ -42,7 +42,7 @@ public class TrinketsClient implements ClientModInitializer {
 						if (slots != null) {
 							TrinketInventory inv = slots.get(slot);
 							if (inv != null) {
-								inv.applySyncTag(entry.getValue());
+								inv.applySyncMetadata(entry.getValue());
 							}
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/api/TrinketSaveData.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketSaveData.java
@@ -1,0 +1,43 @@
+package dev.emi.trinkets.api;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.codec.PacketCodecs;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public record TrinketSaveData(Map<String, Map<String, InventoryData>> data) {
+    public static final Codec<TrinketSaveData> CODEC = Codec.unboundedMap(Codec.STRING, Codec.unboundedMap(Codec.STRING, InventoryData.CODEC)).xmap(TrinketSaveData::new, TrinketSaveData::data);
+    public static final MapCodec<TrinketSaveData> MAP_CODEC = MapCodec.assumeMapUnsafe(CODEC);
+    public record Metadata(List<EntityAttributeModifier> persistentModifiers, List<EntityAttributeModifier> cachedModifiers) {
+        public static final Metadata EMPTY = new Metadata(List.of(), List.of());
+        public static final Codec<Metadata> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+                EntityAttributeModifier.CODEC.listOf().optionalFieldOf("PersistentModifiers", List.of()).forGetter(Metadata::persistentModifiers),
+                EntityAttributeModifier.CODEC.listOf().optionalFieldOf("CachedModifiers", List.of()).forGetter(Metadata::cachedModifiers)
+        ).apply(instance, Metadata::new));
+
+        public static final PacketCodec<RegistryByteBuf, Metadata> PACKET_CODEC = PacketCodec.tuple(
+                PacketCodecs.collection(ArrayList::new, EntityAttributeModifier.PACKET_CODEC), Metadata::persistentModifiers,
+                PacketCodecs.collection(ArrayList::new, EntityAttributeModifier.PACKET_CODEC), Metadata::cachedModifiers,
+                Metadata::new
+        );
+
+        public static final PacketCodec<RegistryByteBuf, Metadata> PACKET_CODEC_PERSISTENT_ONLY = PacketCodec.tuple(
+                PacketCodecs.collection(ArrayList::new, EntityAttributeModifier.PACKET_CODEC), Metadata::persistentModifiers,
+                list -> new Metadata(list, List.of())
+        );
+    }
+    public record InventoryData(Metadata metadata, List<ItemStack> items) {
+        public static final Codec<InventoryData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+                Metadata.CODEC.optionalFieldOf("Metadata", Metadata.EMPTY).forGetter(InventoryData::metadata),
+                ItemStack.OPTIONAL_CODEC.listOf().optionalFieldOf("Items", List.of()).forGetter(InventoryData::items)
+        ).apply(instance, InventoryData::new));
+    }
+}

--- a/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
@@ -1,9 +1,12 @@
 package dev.emi.trinkets.mixin;
 
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -16,6 +19,7 @@ import dev.emi.trinkets.SurvivalTrinketSlot;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.emi.trinkets.TrinketScreen;
 import dev.emi.trinkets.TrinketScreenManager;
+import dev.emi.trinkets.TrinketSlot;
 import dev.emi.trinkets.TrinketsClient;
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.TrinketsApi;
@@ -34,6 +38,8 @@ import net.minecraft.util.collection.DefaultedList;
  */
 @Mixin(CreativeInventoryScreen.class)
 public abstract class CreativeInventoryScreenMixin extends HandledScreen<CreativeScreenHandler> implements TrinketScreen {
+	@Unique
+	private static final Identifier SLOT_HIGHLIGHT_FRONT_TEXTURE = Identifier.ofVanilla("container/slot_highlight_front");
 	@Shadow
 	private static ItemGroup selectedTab;
 	@Shadow
@@ -103,13 +109,26 @@ public abstract class CreativeInventoryScreenMixin extends HandledScreen<Creativ
 		}
 	}
 
-	@Inject(at = @At("TAIL"), method = "drawForeground")
-	private void drawForeground(DrawContext context, int mouseX, int mouseY, CallbackInfo info) {
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER),
+			method = "render")
+	private void drawForeground(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
 		if (selectedTab.getType() == ItemGroup.Type.INVENTORY) {
+			context.getMatrices().pushMatrix();
+			context.getMatrices().translate(this.x, this.y);
 			TrinketScreenManager.drawActiveGroup(context);
+
+			for (Slot slot : this.handler.slots) {
+				if (slot instanceof TrinketSlot trinketSlot && trinketSlot.renderAfterRegularSlots() && slot.isEnabled()) {
+					this.drawSlot(context, slot);
+					if (slot == this.focusedSlot && slot.canBeHighlighted()) {
+						context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SLOT_HIGHLIGHT_FRONT_TEXTURE, this.focusedSlot.x - 4, this.focusedSlot.y - 4, 24, 24);
+					}
+				}
+			}
+			context.getMatrices().popMatrix();
 		}
 	}
-	
+
 	@Inject(at = @At("HEAD"), method = "isClickOutsideBounds", cancellable = true)
 	private void isClickOutsideBounds(double mouseX, double mouseY, int left, int top, int button, CallbackInfoReturnable<Boolean> info) {
 		if (selectedTab.getType() == ItemGroup.Type.INVENTORY && TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY)) {

--- a/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
@@ -13,6 +13,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import dev.emi.trinkets.CreativeTrinketScreen;
 import dev.emi.trinkets.CreativeTrinketSlot;
 import dev.emi.trinkets.Point;
 import dev.emi.trinkets.SurvivalTrinketSlot;
@@ -37,7 +38,7 @@ import net.minecraft.util.collection.DefaultedList;
  * @author Emi
  */
 @Mixin(CreativeInventoryScreen.class)
-public abstract class CreativeInventoryScreenMixin extends HandledScreen<CreativeScreenHandler> implements TrinketScreen {
+public abstract class CreativeInventoryScreenMixin extends HandledScreen<CreativeScreenHandler> implements TrinketScreen, CreativeTrinketScreen {
 	@Unique
 	private static final Identifier SLOT_HIGHLIGHT_FRONT_TEXTURE = Identifier.ofVanilla("container/slot_highlight_front");
 	@Shadow
@@ -109,9 +110,8 @@ public abstract class CreativeInventoryScreenMixin extends HandledScreen<Creativ
 		}
 	}
 
-	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;render(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER),
-			method = "render")
-	private void drawForeground(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+	@Override
+	public void trinkets$renderCreative(DrawContext context, int mouseX, int mouseY, float deltaTicks) {
 		if (selectedTab.getType() == ItemGroup.Type.INVENTORY) {
 			context.getMatrices().pushMatrix();
 			context.getMatrices().translate(this.x, this.y);

--- a/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
@@ -2,6 +2,7 @@ package dev.emi.trinkets.mixin;
 
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import dev.emi.trinkets.CreativeTrinketScreen;
 import dev.emi.trinkets.TrinketScreenManager;
 import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
@@ -75,6 +76,13 @@ public abstract class HandledScreenMixin extends Screen {
 				context.drawTexture(RenderPipelines.GUI_TEXTURED, slotTextureId, slot.x, slot.y, 0, 0, 16, 16, 16, 16);
 				context.drawTexture(RenderPipelines.GUI_TEXTURED, MORE_SLOTS, slot.x - 1, slot.y - 1, 4, 4, 18, 18, 256, 256);
 			}
+		}
+	}
+
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/HandledScreen;renderMain(Lnet/minecraft/client/gui/DrawContext;IIF)V", shift = At.Shift.AFTER), method = "render")
+	private void renderCreativeSlots(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+		if (this instanceof CreativeTrinketScreen screen) {
+			screen.trinkets$renderCreative(context, mouseX, mouseY, deltaTicks);
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
@@ -50,12 +50,6 @@ public abstract class InventoryScreenMixin extends RecipeBookScreen<PlayerScreen
 		TrinketScreenManager.drawExtraGroups(context);
 	}
 
-	@Inject(at = @At("TAIL"), method = "drawForeground")
-	private void drawForeground(DrawContext context, int mouseX, int mouseY, CallbackInfo info) {
-		TrinketScreenManager.drawActiveGroup(context);
-	}
-
-
 	@Override
 	public TrinketPlayerScreenHandler trinkets$getHandler() {
 		return (TrinketPlayerScreenHandler) this.handler;

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -10,13 +10,12 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 import dev.emi.trinkets.TrinketModifiers;
-import dev.emi.trinkets.api.SlotAttributes;
 import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.SlotType;
-import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketComponent;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.TrinketSaveData;
 import dev.emi.trinkets.api.event.TrinketEquipCallback;
 import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import dev.emi.trinkets.payload.SyncInventoryPayload;
@@ -50,9 +49,7 @@ import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 
@@ -235,10 +232,10 @@ public abstract class LivingEntityMixin extends Entity {
 				Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
 
 				if (!contentUpdates.isEmpty() || !inventoriesToSend.isEmpty()) {
-                    Map<String, NbtCompound> map = new HashMap<>();
+                    Map<String, TrinketSaveData.Metadata> map = new HashMap<>();
 
 					for (TrinketInventory trinketInventory : inventoriesToSend) {
-						map.put(trinketInventory.getSlotType().getId(), trinketInventory.getSyncTag());
+						map.put(trinketInventory.getSlotType().getId(), trinketInventory.getSyncMetadata());
 					}
                     SyncInventoryPayload packet = new SyncInventoryPayload(this.getId(), contentUpdates, map);
 

--- a/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/PlayerManagerMixin.java
@@ -3,6 +3,7 @@ package dev.emi.trinkets.mixin;
 
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.emi.trinkets.api.TrinketInventory;
+import dev.emi.trinkets.api.TrinketSaveData;
 import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.EntitySlotLoader;
 
@@ -12,7 +13,6 @@ import java.util.Set;
 
 import dev.emi.trinkets.payload.SyncInventoryPayload;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ConnectedClientData;
@@ -35,11 +35,11 @@ public abstract class PlayerManagerMixin {
 		EntitySlotLoader.SERVER.sync(player);
 		((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(false);
 		TrinketsApi.getTrinketComponent(player).ifPresent(trinkets -> {
-			Map<String, NbtCompound> tag = new HashMap<>();
+			Map<String, TrinketSaveData.Metadata> tag = new HashMap<>();
 			Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
 
 			for (TrinketInventory trinketInventory : inventoriesToSend) {
-				tag.put(trinketInventory.getSlotType().getId(), trinketInventory.getSyncTag());
+				tag.put(trinketInventory.getSlotType().getId(), trinketInventory.getSyncMetadata());
 			}
 			ServerPlayNetworking.send(player, new SyncInventoryPayload(player.getId(), Map.of(), tag));
 			inventoriesToSend.clear();

--- a/src/main/java/dev/emi/trinkets/mixin/RecipeBookScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/RecipeBookScreenMixin.java
@@ -1,18 +1,58 @@
 package dev.emi.trinkets.mixin;
 
 import dev.emi.trinkets.TrinketScreenManager;
+import dev.emi.trinkets.TrinketSlot;
+import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.gui.screen.ingame.RecipeBookScreen;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.AbstractRecipeScreenHandler;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(RecipeBookScreen.class)
-public class RecipeBookScreenMixin {
+public abstract class RecipeBookScreenMixin extends HandledScreen<AbstractRecipeScreenHandler> {
+    @Unique
+    private static final Identifier SLOT_HIGHLIGHT_FRONT_TEXTURE = Identifier.ofVanilla("container/slot_highlight_front");
+
+    public RecipeBookScreenMixin(AbstractRecipeScreenHandler handler, PlayerInventory inventory, Text title) {
+        super(handler, inventory, title);
+    }
+
+
     @Inject(at = @At("HEAD"), method = "isClickOutsideBounds", cancellable = true)
     private void isClickOutsideBounds(double mouseX, double mouseY, int left, int top, int button, CallbackInfoReturnable<Boolean> info) {
         if (TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY)) {
             info.setReturnValue(false);
+        }
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/ingame/RecipeBookScreen;renderCursorStack(Lnet/minecraft/client/gui/DrawContext;II)V", shift = At.Shift.BEFORE),
+            method = "render")
+    private void drawForeground(DrawContext context, int mouseX, int mouseY, float deltaTicks, CallbackInfo ci) {
+        if (((Object) this) instanceof InventoryScreen) {
+            context.getMatrices().pushMatrix();
+            context.getMatrices().translate(this.x, this.y);
+            TrinketScreenManager.drawActiveGroup(context);
+
+            for (Slot slot : this.handler.slots) {
+                if (slot instanceof TrinketSlot trinketSlot && trinketSlot.renderAfterRegularSlots() && slot.isEnabled()) {
+                    this.drawSlot(context, slot);
+                    if (slot == this.focusedSlot && slot.canBeHighlighted()) {
+                        context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SLOT_HIGHLIGHT_FRONT_TEXTURE, this.focusedSlot.x - 4, this.focusedSlot.y - 4, 24, 24);
+                    }
+                }
+            }
+            context.getMatrices().popMatrix();
         }
     }
 }

--- a/src/main/java/dev/emi/trinkets/payload/SyncInventoryPayload.java
+++ b/src/main/java/dev/emi/trinkets/payload/SyncInventoryPayload.java
@@ -1,8 +1,8 @@
 package dev.emi.trinkets.payload;
 
 import dev.emi.trinkets.TrinketsNetwork;
+import dev.emi.trinkets.api.TrinketSaveData;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
@@ -11,13 +11,13 @@ import net.minecraft.network.packet.CustomPayload;
 import java.util.HashMap;
 import java.util.Map;
 
-public record SyncInventoryPayload(int entityId, Map<String, ItemStack> contentUpdates, Map<String, NbtCompound> inventoryUpdates) implements CustomPayload {
+public record SyncInventoryPayload(int entityId, Map<String, ItemStack> contentUpdates, Map<String, TrinketSaveData.Metadata> inventoryUpdates) implements CustomPayload {
 	public static final PacketCodec<RegistryByteBuf, SyncInventoryPayload> CODEC = PacketCodec.tuple(
 			PacketCodecs.VAR_INT,
 			SyncInventoryPayload::entityId,
 			PacketCodecs.map(HashMap::new, PacketCodecs.STRING, ItemStack.OPTIONAL_PACKET_CODEC),
 			SyncInventoryPayload::contentUpdates,
-			PacketCodecs.map(HashMap::new, PacketCodecs.STRING, PacketCodecs.NBT_COMPOUND),
+			PacketCodecs.map(HashMap::new, PacketCodecs.STRING, TrinketSaveData.Metadata.PACKET_CODEC_PERSISTENT_ONLY),
 			SyncInventoryPayload::inventoryUpdates,
 			SyncInventoryPayload::new);
 	@Override

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -56,8 +56,8 @@
 	],
 
 	"depends": {
-		"minecraft": ">1.18",
-		"fabricloader": ">=0.7.0",
+		"minecraft": ">=1.21.6",
+		"fabricloader": ">=0.16.0",
 		"cardinal-components-base": ">=3.0.0-0",
 		"cardinal-components-entity": ">=3.0.0-0",
 		"fabric-api": ">=0.51.2"


### PR DESCRIPTION
Biggest change is how data is saved/loaded. It now uses intermediary object, as it needed to go through codecs now. Reason why is that MC no longer uses nbt directly for saving and loading, but instead moving to Write/Read View wrapper classes. This also applies to synchronized data, through it still is baked by slightly modified save.

Bit smaller but still notable, there were some changes / moving of how the gui is rendering too (as Mojang also refactored that too), eliminating usage of z translations within the user code. Everything should look the same as in 1.21.5 through. 