### PR TITLE
1.20.1 Slot Modification and GUI fixes

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketScreen.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreen.java
@@ -20,6 +20,10 @@ public interface TrinketScreen {
 		return false;
 	}
 
+	public default boolean trinkets$isNarrow() {
+		return false;
+	}
+
 	public default void trinkets$updateTrinketSlots() {
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -25,7 +25,6 @@ public class TrinketScreenManager {
 	public static SlotGroup quickMoveGroup = null;
 
 	public static void init(TrinketScreen screen) {
-		System.out.println(screen);
 		currentScreen = screen;
 		group = null;
 		currentBounds = new Rect2i(0, 0, 0, 0);

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -316,6 +316,10 @@ public class TrinketScreenManager {
 
 	public static boolean isClickInsideTrinketBounds(double mouseX, double mouseY) {
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
+		if (currentScreen.trinkets$getFocusedSlot() instanceof TrinketSlot) {
+			return true;
+		}
+
 		int x = currentScreen.trinkets$getX();
 		int y = currentScreen.trinkets$getY();
 		int mx = (int) (Math.round(mouseX) - x);

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -123,9 +123,11 @@ public class TrinketScreenManager {
 					continue;
 				}
 				if (r.contains(Math.round(mouseX) - x, Math.round(mouseY) - y)) {
-					TrinketsClient.activeGroup = g;
-					TrinketsClient.quickMoveGroup = null;
-					break;
+					if (!(currentScreen.trinkets$isNarrow() && currentScreen.trinkets$isRecipeBookOpen())) {
+						TrinketsClient.activeGroup = g;
+						TrinketsClient.quickMoveGroup = null;
+						break;
+					}
 				}
 			}
 		}

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -54,7 +54,17 @@ public class TrinketScreenManager {
 		if (group != null) {
 			if (TrinketsClient.activeType != null) {
 				if (!typeBounds.contains(Math.round(mouseX) - x, Math.round(mouseY) - y)) {
-					TrinketsClient.activeType = null;
+					// Attempt to refresh the typeBounds, in case the slot count has changed.
+					int i = handler.trinkets$getSlotTypes(group).indexOf(TrinketsClient.activeType);
+					if (i >= 0) {
+						Rect2i r = currentScreen.trinkets$getGroupRect(group);
+                        Point slotHeight = handler.trinkets$getSlotHeight(group, i);
+						int height = slotHeight.y();
+						typeBounds = new Rect2i(r.getX() + slotHeight.x() - 2, r.getY() - (height - 1) / 2 * 18 - 3, 23, height * 18 + 5);
+					}
+					if (!typeBounds.contains(Math.round(mouseX) - x, Math.round(mouseY) - y)) {
+						TrinketsClient.activeType = null;
+					}
 				} else if (focusedSlot != null) {
 					if (!(focusedSlot instanceof TrinketSlot ts && ts.getType() == TrinketsClient.activeType)) {
 						TrinketsClient.activeType = null;
@@ -377,6 +387,7 @@ public class TrinketScreenManager {
 
 		if (currentScreen != null) {
 			currentScreen.trinkets$updateTrinketSlots();
+			typeBounds = new Rect2i(0, 0, 0, 0);
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -25,9 +25,15 @@ public class TrinketScreenManager {
 	public static SlotGroup quickMoveGroup = null;
 
 	public static void init(TrinketScreen screen) {
+		System.out.println(screen);
 		currentScreen = screen;
 		group = null;
 		currentBounds = new Rect2i(0, 0, 0, 0);
+	}
+
+	public static void close() {
+		removeSelections();
+		init(null);
 	}
 
 	public static void removeSelections() {
@@ -36,6 +42,11 @@ public class TrinketScreenManager {
 	}
 
 	public static void update(float mouseX, float mouseY) {
+		TrinketScreen currentScreen = getCurrentScreen();
+		if (currentScreen == null) {
+			return;
+		}
+
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
 		Slot focusedSlot = currentScreen.trinkets$getFocusedSlot();
 		int x = currentScreen.trinkets$getX();
@@ -183,6 +194,11 @@ public class TrinketScreenManager {
 	}
 
 	public static void drawGroup(DrawContext context, SlotGroup group, SlotType type) {
+		TrinketScreen currentScreen = getCurrentScreen();
+		if (currentScreen == null) {
+			return;
+		}
+
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
 		RenderSystem.enableDepthTest();
 		context.getMatrices().push();
@@ -267,6 +283,11 @@ public class TrinketScreenManager {
 	}
 
 	public static void drawExtraGroups(DrawContext context) {
+		TrinketScreen currentScreen = getCurrentScreen();
+		if (currentScreen == null) {
+			return;
+		}
+
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
 		int x = currentScreen.trinkets$getX();
 		int y = currentScreen.trinkets$getY();
@@ -315,6 +336,11 @@ public class TrinketScreenManager {
 	}
 
 	public static boolean isClickInsideTrinketBounds(double mouseX, double mouseY) {
+		TrinketScreen currentScreen = getCurrentScreen();
+		if (currentScreen == null || MinecraftClient.getInstance().currentScreen != currentScreen) {
+			return false;
+		}
+
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
 		if (currentScreen.trinkets$getFocusedSlot() instanceof TrinketSlot) {
 			return true;
@@ -344,5 +370,17 @@ public class TrinketScreenManager {
 			}
 		}
 		return false;
+	}
+
+	static void tryUpdateTrinketsSlot() {
+		TrinketScreen currentScreen = getCurrentScreen();
+
+		if (currentScreen != null) {
+			currentScreen.trinkets$updateTrinketSlots();
+		}
+	}
+
+	public static TrinketScreen getCurrentScreen() {
+		return currentScreen;
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -80,9 +80,7 @@ public class TrinketsClient implements ClientModInitializer {
 
 						if (entity instanceof PlayerEntity && ((PlayerEntity) entity).playerScreenHandler instanceof TrinketPlayerScreenHandler screenHandler) {
 							screenHandler.trinkets$updateTrinketSlots(false);
-							if (TrinketScreenManager.currentScreen != null) {
-								TrinketScreenManager.currentScreen.trinkets$updateTrinketSlots();
-							}
+                            TrinketScreenManager.tryUpdateTrinketsSlot();
 						}
 
 						for (Pair<String, ItemStack> entry : contentUpdates) {

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -82,9 +82,6 @@ public class TrinketsClient implements ClientModInitializer {
 						if (entity instanceof PlayerEntity && ((PlayerEntity) entity).playerScreenHandler instanceof TrinketPlayerScreenHandler screenHandler) {
 							screenHandler.trinkets$updateTrinketSlots(false);
                             TrinketScreenManager.tryUpdateTrinketsSlot();
-						} else if (client.player != null && client.player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(client.player.playerScreenHandler)) {
-							screenHandler.trinkets$updateTrinketSlots(false);
-							TrinketScreenManager.tryUpdateTrinketsSlot();
 						}
 
 						for (Pair<String, ItemStack> entry : contentUpdates) {

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -82,6 +82,9 @@ public class TrinketsClient implements ClientModInitializer {
 						if (entity instanceof PlayerEntity && ((PlayerEntity) entity).playerScreenHandler instanceof TrinketPlayerScreenHandler screenHandler) {
 							screenHandler.trinkets$updateTrinketSlots(false);
                             TrinketScreenManager.tryUpdateTrinketsSlot();
+						} else if (client.player != null && client.player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(client.player.playerScreenHandler)) {
+							screenHandler.trinkets$updateTrinketSlots(false);
+							TrinketScreenManager.tryUpdateTrinketsSlot();
 						}
 
 						for (Pair<String, ItemStack> entry : contentUpdates) {
@@ -144,6 +147,11 @@ public class TrinketsClient implements ClientModInitializer {
 							if (clientWorldEntity instanceof LivingEntity livingEntity) {
 								TrinketsApi.getTrinketComponent(livingEntity).ifPresent(TrinketComponent::update);
 							}
+						}
+
+						if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
+							screenHandler.trinkets$updateTrinketSlots(false);
+							TrinketScreenManager.tryUpdateTrinketsSlot();
 						}
 					}
 				});

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -21,6 +21,7 @@ import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.TrinketComponent;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.network.ClientPlayerEntity;
@@ -137,6 +138,12 @@ public class TrinketsClient implements ClientModInitializer {
 
 						for (AbstractClientPlayerEntity clientWorldPlayer : player.clientWorld.getPlayers()) {
 							((TrinketPlayerScreenHandler) clientWorldPlayer.playerScreenHandler).trinkets$updateTrinketSlots(true);
+						}
+
+						for (Entity clientWorldEntity : player.clientWorld.getEntities()) {
+							if (clientWorldEntity instanceof LivingEntity livingEntity) {
+								TrinketsApi.getTrinketComponent(livingEntity).ifPresent(TrinketComponent::update);
+							}
 						}
 					}
 				});

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -5,6 +5,9 @@ import static com.mojang.brigadier.arguments.StringArgumentType.string;
 import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,8 +46,10 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.SERVER);
-		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success)
-				-> EntitySlotLoader.SERVER.sync(server.getPlayerManager().getPlayerList()));
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success) -> {
+			EntitySlotLoader.SERVER.sync(server.getPlayerManager().getPlayerList());
+			EntitySlotLoader.SERVER.updateEntities(server);
+		});
 		CommandRegistrationCallback.EVENT.register((dispatcher, registry, env) -> 
 			dispatcher.register(literal("trinkets")
 				.requires(source -> source.hasPermissionLevel(2))

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -194,6 +194,17 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
 		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(stack, ref, this.getEntity(), uuid);
 		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+
+		// MC-272769 Mitigation.
+		Multimap<EntityAttribute, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
+		this.forEach(((slotReference, itemStack) -> {
+			if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
+				UUID slotUuid = SlotAttributes.getUuid(slotReference);
+				existsElsewhere.putAll(trinket.getModifiers(itemStack, slotReference, entity, slotUuid));
+			}
+		}));
+		existsElsewhere.forEach(map::remove);
+
 		Set<SlotAttributes.SlotEntityAttribute> toRemove = Sets.newHashSet();
 		for (EntityAttribute attr : map.keySet()) {
 			if (attr instanceof SlotAttributes.SlotEntityAttribute slotAttr) {
@@ -204,15 +215,6 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		for (SlotAttributes.SlotEntityAttribute attr : toRemove) {
 			map.removeAll(attr);
 		}
-        // MC-272769 Mitigation.
-		Multimap<EntityAttribute, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
-		this.forEach(((slotReference, itemStack) -> {
-            if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
-                UUID slotUuid = SlotAttributes.getUuid(slotReference);
-                existsElsewhere.putAll(trinket.getModifiers(itemStack, slotReference, entity, slotUuid));
-            }
-        }));
-		existsElsewhere.forEach(map::remove);
 		this.getEntity().getAttributes().removeModifiers(map);
 		this.removeModifiers(slotMap);
 	}

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -82,7 +82,9 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
-								this.processSlotModifiers(new SlotReference(oldInv, i), stack, ItemStack.EMPTY);
+								SlotReference ref = new SlotReference(oldInv, i);
+								this.processSlotModifiers(ref, stack, ItemStack.EMPTY);
+								TrinketsApi.getTrinket(stack.getItem()).onUnequip(stack, ref, entity);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else {

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Multimap;
 
 import com.google.common.collect.Sets;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
+import dev.emi.trinkets.TrinketsMain;
 import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.entity.LivingEntity;
@@ -27,6 +28,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Pair;
 import net.minecraft.util.collection.DefaultedList;
 
@@ -90,7 +92,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 								}
 								droppedItems.put(ref, oldStack);
 								if (this.entity instanceof PlayerEntity player) {
-									player.getInventory().offerOrDrop(stack);
+									player.getInventory().offerOrDrop(stack.copy());
 								} else {
 									this.entity.dropStack(stack);
 								}
@@ -102,12 +104,29 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 				count += inv.size();
 			}
 		}
+
+		// Handle dropping newly slotless items.
+		forEach((ref, itemStack) -> {
+			if (!groups.containsKey(ref.getSlotType().getGroup()) || !groups.get(ref.getSlotType().getGroup()).getSlots().containsKey(ref.getSlotType().getName())) {
+				droppedItems.put(ref, itemStack);
+				if (this.entity instanceof PlayerEntity player) {
+					player.getInventory().offerOrDrop(itemStack.copy());
+				} else {
+					this.entity.dropStack(itemStack);
+				}
+			}
+		});
+
 		size = count;
 		this.inventory = inventory;
 		for (Map.Entry<SlotReference, ItemStack> dropped : droppedItems.entrySet()) {
-			this.processSlotModifiers(dropped.getKey(), dropped.getValue(), ItemStack.EMPTY);
-			TrinketsApi.getTrinket(dropped.getValue().getItem()).onUnequip(dropped.getValue(), dropped.getKey(), entity);
-			dropped.getKey().set(ItemStack.EMPTY);
+			try {
+				this.processSlotModifiers(dropped.getKey(), dropped.getValue(), ItemStack.EMPTY);
+				TrinketsApi.getTrinket(dropped.getValue().getItem()).onUnequip(dropped.getValue(), dropped.getKey(), entity);
+				dropped.getKey().set(ItemStack.EMPTY);
+			} catch (Exception e) {
+				TrinketsMain.LOGGER.warn("Caught exception when dropping {} from removed slot {}.", dropped.getValue(), dropped.getKey().getId());
+			}
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 
+import com.google.common.collect.Sets;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.onyxstudios.cca.api.v3.component.sync.AutoSyncedComponent;
 import net.fabricmc.fabric.api.util.NbtType;
@@ -81,6 +82,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
+								this.clearSlotModifiers(stack, new SlotReference(oldInv, i));
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else {
@@ -185,6 +187,25 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 				slotType.getValue().clearModifiers();
 			}
 		}
+	}
+
+	public void clearSlotModifiers(ItemStack oldStack, SlotReference ref) {
+		UUID uuid = SlotAttributes.getUuid(ref);
+		Trinket trinket = TrinketsApi.getTrinket(oldStack.getItem());
+		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(oldStack, ref, this.getEntity(), uuid);
+		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+		Set<SlotAttributes.SlotEntityAttribute> toRemove = Sets.newHashSet();
+		for (EntityAttribute attr : map.keySet()) {
+			if (attr instanceof SlotAttributes.SlotEntityAttribute slotAttr) {
+				slotMap.putAll(slotAttr.slot, map.get(attr));
+				toRemove.add(slotAttr);
+			}
+		}
+		for (SlotAttributes.SlotEntityAttribute attr : toRemove) {
+			map.removeAll(attr);
+		}
+		this.getEntity().getAttributes().removeModifiers(map);
+		this.removeModifiers(slotMap);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -410,4 +410,10 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 			}
 		}
 	}
+
+	public interface StackHistory {
+		default ItemStack trinkets$getOldStack(SlotReference ref) {
+			return ItemStack.EMPTY;
+		}
+	}
 }

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -83,13 +83,18 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 								inv.setStack(i, stack);
 							} else {
 								SlotReference ref = new SlotReference(oldInv, i);
-								this.processSlotModifiers(ref, stack, ItemStack.EMPTY);
-								TrinketsApi.getTrinket(stack.getItem()).onUnequip(stack, ref, entity);
+								ItemStack oldStack = stack;
+								if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory && !stackHistory.trinkets$getOldStack(ref).isEmpty()) {
+									oldStack = stackHistory.trinkets$getOldStack(ref);
+								}
+								this.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
+								TrinketsApi.getTrinket(stack.getItem()).onUnequip(oldStack, ref, entity);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else {
 									this.entity.dropStack(stack);
 								}
+								oldInv.getStack(i).setCount(0);
 							}
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -82,7 +82,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
-								this.removeSlotModifiers(stack, new SlotReference(oldInv, i));
+								this.processSlotModifiers(new SlotReference(oldInv, i), stack, ItemStack.EMPTY);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else {
@@ -189,53 +189,48 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 	}
 
-	public void removeSlotModifiers(ItemStack stack, SlotReference ref) {
+	public void processSlotModifiers(SlotReference ref, ItemStack oldStack, ItemStack newStack) {
 		UUID uuid = SlotAttributes.getUuid(ref);
-		Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
-		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(stack, ref, this.getEntity(), uuid);
-		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+		Trinket oldTrinket = TrinketsApi.getTrinket(oldStack.getItem());
+		Trinket newTrinket = TrinketsApi.getTrinket(newStack.getItem());
+		// TODO: Check if empty, if so, static empty Multimap?
+		Multimap<EntityAttribute, EntityAttributeModifier> removeModifiers = oldTrinket.getModifiers(oldStack, ref, this.getEntity(), uuid);
+		Multimap<EntityAttribute, EntityAttributeModifier> addModifiers = newTrinket.getModifiers(newStack, ref, this.getEntity(), uuid);
+		Multimap<String, EntityAttributeModifier> removeSlotMap = HashMultimap.create(), addSlotMap = HashMultimap.create();
 
 		// MC-272769 Mitigation.
 		Multimap<EntityAttribute, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
 		this.forEach(((slotReference, itemStack) -> {
 			if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
 				UUID slotUuid = SlotAttributes.getUuid(slotReference);
-				existsElsewhere.putAll(trinket.getModifiers(itemStack, slotReference, entity, slotUuid));
+				Trinket otherTrinket = TrinketsApi.getTrinket(itemStack.getItem());
+				existsElsewhere.putAll(otherTrinket.getModifiers(itemStack, slotReference, entity, slotUuid));
 			}
 		}));
-		existsElsewhere.forEach(map::remove);
+		existsElsewhere.forEach(removeModifiers::remove);
 
 		Set<SlotAttributes.SlotEntityAttribute> toRemove = Sets.newHashSet();
-		for (EntityAttribute attr : map.keySet()) {
+		for (EntityAttribute attr : removeModifiers.keySet()) {
 			if (attr instanceof SlotAttributes.SlotEntityAttribute slotAttr) {
-				slotMap.putAll(slotAttr.slot, map.get(attr));
+				removeSlotMap.putAll(slotAttr.slot, removeModifiers.get(attr));
 				toRemove.add(slotAttr);
 			}
 		}
-		for (SlotAttributes.SlotEntityAttribute attr : toRemove) {
-			map.removeAll(attr);
-		}
-		this.getEntity().getAttributes().removeModifiers(map);
-		this.removeModifiers(slotMap);
-	}
-
-	public void addSlotModifiers(ItemStack stack, SlotReference ref) {
-		UUID uuid = SlotAttributes.getUuid(ref);
-		Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
-		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(stack, ref, entity, uuid);
-		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
-		Set<SlotAttributes.SlotEntityAttribute> toRemove = Sets.newHashSet();
-		for (EntityAttribute attr : map.keySet()) {
+		for (EntityAttribute attr : addModifiers.keySet()) {
 			if (attr instanceof SlotAttributes.SlotEntityAttribute slotAttr) {
-				slotMap.putAll(slotAttr.slot, map.get(attr));
+				addSlotMap.putAll(slotAttr.slot, addModifiers.get(attr));
 				toRemove.add(slotAttr);
 			}
 		}
+
 		for (SlotAttributes.SlotEntityAttribute attr : toRemove) {
-			map.removeAll(attr);
+			removeModifiers.removeAll(attr);
+			addModifiers.removeAll(attr);
 		}
-		this.getEntity().getAttributes().addTemporaryModifiers(map);
-		this.addTemporaryModifiers(slotMap);
+		this.getEntity().getAttributes().removeModifiers(removeModifiers);
+		this.getEntity().getAttributes().addTemporaryModifiers(addModifiers);
+		this.removeModifiers(removeSlotMap);
+		this.addTemporaryModifiers(addSlotMap);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -65,6 +65,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		Map<String, SlotGroup> entitySlots = TrinketsApi.getEntitySlots(this.entity);
 		int count = 0;
 		groups.clear();
+		Map<SlotReference, ItemStack> droppedItems = new HashMap<>();
 		Map<String, Map<String, TrinketInventory>> inventory = new HashMap<>();
 		for (Map.Entry<String, SlotGroup> group : entitySlots.entrySet()) {
 			String groupKey = group.getKey();
@@ -87,14 +88,12 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 								if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory && !stackHistory.trinkets$getOldStack(ref).isEmpty()) {
 									oldStack = stackHistory.trinkets$getOldStack(ref);
 								}
-								this.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
-								TrinketsApi.getTrinket(stack.getItem()).onUnequip(oldStack, ref, entity);
+								droppedItems.put(ref, oldStack);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else {
 									this.entity.dropStack(stack);
 								}
-								oldInv.getStack(i).setCount(0);
 							}
 						}
 					}
@@ -105,6 +104,11 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 		size = count;
 		this.inventory = inventory;
+		for (Map.Entry<SlotReference, ItemStack> dropped : droppedItems.entrySet()) {
+			this.processSlotModifiers(dropped.getKey(), dropped.getValue(), ItemStack.EMPTY);
+			TrinketsApi.getTrinket(dropped.getValue().getItem()).onUnequip(dropped.getValue(), dropped.getKey(), entity);
+			dropped.getKey().set(ItemStack.EMPTY);
+		}
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -204,6 +204,15 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		for (SlotAttributes.SlotEntityAttribute attr : toRemove) {
 			map.removeAll(attr);
 		}
+        // MC-272769 Mitigation.
+		Multimap<EntityAttribute, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
+		this.forEach(((slotReference, itemStack) -> {
+            if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
+                UUID slotUuid = SlotAttributes.getUuid(slotReference);
+                existsElsewhere.putAll(trinket.getModifiers(itemStack, slotReference, entity, slotUuid));
+            }
+        }));
+		existsElsewhere.forEach(map::remove);
 		this.getEntity().getAttributes().removeModifiers(map);
 		this.removeModifiers(slotMap);
 	}

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -189,10 +189,10 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 	}
 
-	public void removeSlotModifiers(ItemStack oldStack, SlotReference ref) {
+	public void removeSlotModifiers(ItemStack stack, SlotReference ref) {
 		UUID uuid = SlotAttributes.getUuid(ref);
-		Trinket trinket = TrinketsApi.getTrinket(oldStack.getItem());
-		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(oldStack, ref, this.getEntity(), uuid);
+		Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
+		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(stack, ref, this.getEntity(), uuid);
 		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
 		Set<SlotAttributes.SlotEntityAttribute> toRemove = Sets.newHashSet();
 		for (EntityAttribute attr : map.keySet()) {

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -82,7 +82,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
-								this.clearSlotModifiers(stack, new SlotReference(oldInv, i));
+								this.removeSlotModifiers(stack, new SlotReference(oldInv, i));
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else {
@@ -189,7 +189,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 	}
 
-	public void clearSlotModifiers(ItemStack oldStack, SlotReference ref) {
+	public void removeSlotModifiers(ItemStack oldStack, SlotReference ref) {
 		UUID uuid = SlotAttributes.getUuid(ref);
 		Trinket trinket = TrinketsApi.getTrinket(oldStack.getItem());
 		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(oldStack, ref, this.getEntity(), uuid);
@@ -206,6 +206,25 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 		this.getEntity().getAttributes().removeModifiers(map);
 		this.removeModifiers(slotMap);
+	}
+
+	public void addSlotModifiers(ItemStack stack, SlotReference ref) {
+		UUID uuid = SlotAttributes.getUuid(ref);
+		Trinket trinket = TrinketsApi.getTrinket(stack.getItem());
+		Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(stack, ref, entity, uuid);
+		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+		Set<SlotAttributes.SlotEntityAttribute> toRemove = Sets.newHashSet();
+		for (EntityAttribute attr : map.keySet()) {
+			if (attr instanceof SlotAttributes.SlotEntityAttribute slotAttr) {
+				slotMap.putAll(slotAttr.slot, map.get(attr));
+				toRemove.add(slotAttr);
+			}
+		}
+		for (SlotAttributes.SlotEntityAttribute attr : toRemove) {
+			map.removeAll(attr);
+		}
+		this.getEntity().getAttributes().addTemporaryModifiers(map);
+		this.addTemporaryModifiers(slotMap);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/SlotReference.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotReference.java
@@ -1,7 +1,22 @@
 package dev.emi.trinkets.api;
 
+import net.minecraft.item.ItemStack;
+
 public record SlotReference(TrinketInventory inventory, int index) {
     public String getId() {
         return inventory.getSlotType().getGroup() + "/" + inventory.getSlotType().getName() + "/" + index;
+    }
+
+    public ItemStack get() {
+        return inventory.getStack(index);
+    }
+
+    public boolean set(ItemStack itemStack) {
+        inventory.setStack(index, itemStack);
+        return true;
+    }
+
+    public SlotType getSlotType() {
+        return inventory.getSlotType();
     }
 }

--- a/src/main/java/dev/emi/trinkets/api/SlotReference.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotReference.java
@@ -1,4 +1,7 @@
 package dev.emi.trinkets.api;
 
 public record SlotReference(TrinketInventory inventory, int index) {
+    public String getId() {
+        return inventory.getSlotType().getGroup() + "/" + inventory.getSlotType().getName() + "/" + index;
+    }
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -179,8 +179,13 @@ public class TrinketInventory implements Inventory {
 					if (i < newStacks.size()) {
 						newStacks.set(i, stack);
 					} else {
+						SlotReference ref = new SlotReference(this, i);
+						ItemStack oldStack = stack;
+						if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory) {
+							oldStack = stackHistory.trinkets$getOldStack(ref);
+						}
 						if (!this.getComponent().getEntity().getWorld().isClient && this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-							livingEntityTrinketComponent.processSlotModifiers(new SlotReference(this, i), stack, ItemStack.EMPTY);
+							livingEntityTrinketComponent.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
 						}
 						entity.dropStack(stack);
 					}

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -179,8 +179,8 @@ public class TrinketInventory implements Inventory {
 					if (i < newStacks.size()) {
 						newStacks.set(i, stack);
 					} else {
-						if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-							livingEntityTrinketComponent.removeSlotModifiers(stack, new SlotReference(this, i));
+						if (!this.getComponent().getEntity().getWorld().isClient && this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
+							livingEntityTrinketComponent.processSlotModifiers(new SlotReference(this, i), stack, ItemStack.EMPTY);
 						}
 						entity.dropStack(stack);
 					}

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -184,6 +184,7 @@ public class TrinketInventory implements Inventory {
 						if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory) {
 							oldStack = stackHistory.trinkets$getOldStack(ref);
 						}
+						TrinketsApi.getTrinket(oldStack.getItem()).onUnequip(oldStack, ref, entity);
 						if (!this.getComponent().getEntity().getWorld().isClient && this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
 							livingEntityTrinketComponent.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
 						}

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -189,6 +189,7 @@ public class TrinketInventory implements Inventory {
 							livingEntityTrinketComponent.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
 						}
 						entity.dropStack(stack);
+						ref.set(ItemStack.EMPTY);
 					}
 				}
 

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -177,6 +177,9 @@ public class TrinketInventory implements Inventory {
 					if (i < newStacks.size()) {
 						newStacks.set(i, stack);
 					} else {
+						if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
+							livingEntityTrinketComponent.clearSlotModifiers(stack, new SlotReference(this, i));
+						}
 						entity.dropStack(stack);
 					}
 				}

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -28,6 +28,7 @@ public class TrinketInventory implements Inventory {
 
 	private DefaultedList<ItemStack> stacks;
 	private boolean update = false;
+	private boolean suppressUpdates = false;
 
 	public TrinketInventory(SlotType slotType, TrinketComponent comp, Consumer<TrinketInventory> updateCallback) {
 		this.component = comp;
@@ -153,8 +154,9 @@ public class TrinketInventory implements Inventory {
 	}
 
 	public void update() {
-		if (this.update) {
+		if (this.update && !suppressUpdates) {
 			this.update = false;
+			this.suppressUpdates = true;
 			double baseSize = this.baseSize;
 			for (EntityAttributeModifier mod : this.getModifiersByOperation(EntityAttributeModifier.Operation.ADDITION)) {
 				baseSize += mod.getValue();
@@ -186,6 +188,9 @@ public class TrinketInventory implements Inventory {
 
 				this.stacks = newStacks;
 			}
+			// Process updates sequentially, instead of in the middle of an incomplete update.
+			this.suppressUpdates = false;
+			this.update();
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -181,7 +181,7 @@ public class TrinketInventory implements Inventory {
 					} else {
 						SlotReference ref = new SlotReference(this, i);
 						ItemStack oldStack = stack;
-						if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory) {
+						if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory && !stackHistory.trinkets$getOldStack(ref).isEmpty()) {
 							oldStack = stackHistory.trinkets$getOldStack(ref);
 						}
 						TrinketsApi.getTrinket(oldStack.getItem()).onUnequip(oldStack, ref, entity);

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -178,7 +178,7 @@ public class TrinketInventory implements Inventory {
 						newStacks.set(i, stack);
 					} else {
 						if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-							livingEntityTrinketComponent.clearSlotModifiers(stack, new SlotReference(this, i));
+							livingEntityTrinketComponent.removeSlotModifiers(stack, new SlotReference(this, i));
 						}
 						entity.dropStack(stack);
 					}

--- a/src/main/java/dev/emi/trinkets/api/event/SlotCountModificationCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/SlotCountModificationCallback.java
@@ -1,0 +1,28 @@
+package dev.emi.trinkets.api.event;
+
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketInventory;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import java.util.Set;
+
+/**
+ * Event called upon slot modification by attributes.
+ * Does not trigger upon Datapack Reload.
+ */
+
+public interface SlotCountModificationCallback {
+	Event<SlotCountModificationCallback> EVENT = EventFactory.createArrayBacked(SlotCountModificationCallback.class,
+	listeners -> (component, inventories) -> {
+		for (var listener : listeners) {
+			listener.onChange(component, inventories);
+		}
+	});
+
+	/**
+	 * @param component The TrinketComponent the inventories belong to.
+	 * @param inventories A set of inventories affected by EAM modifications.
+	 */
+	void onChange(TrinketComponent component, Set<TrinketInventory> inventories);
+}

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -214,6 +214,11 @@ public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<Stri
 		PacketByteBuf buf = getSlotsPacket();
 		players.forEach(player -> ServerPlayNetworking.send(player, TrinketsNetwork.SYNC_SLOTS, buf));
 		players.forEach(player -> ((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(true));
+		players.forEach(player -> {
+			if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
+				screenHandler.trinkets$updateTrinketSlots(true);
+			}
+		});
 	}
 
 	public void updateEntities(MinecraftServer server) {

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -22,20 +22,27 @@ import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.TrinketsNetwork;
 import dev.emi.trinkets.api.SlotGroup;
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.SlotLoader.GroupData;
 import dev.emi.trinkets.data.SlotLoader.SlotData;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.registry.Registries;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.SinglePreparationResourceReloader;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
@@ -207,6 +214,16 @@ public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<Stri
 		PacketByteBuf buf = getSlotsPacket();
 		players.forEach(player -> ServerPlayNetworking.send(player, TrinketsNetwork.SYNC_SLOTS, buf));
 		players.forEach(player -> ((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(true));
+	}
+
+	public void updateEntities(MinecraftServer server) {
+		for (ServerWorld world : server.getWorlds()) {
+			for (Entity entity : world.iterateEntities()) {
+				if (entity instanceof LivingEntity livingEntity && !(livingEntity instanceof PlayerEntity)) {
+					TrinketsApi.getTrinketComponent(livingEntity).ifPresent(TrinketComponent::update);
+				}
+			}
+		}
 	}
 
 	private PacketByteBuf getSlotsPacket() {

--- a/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/CreativeInventoryScreenMixin.java
@@ -83,7 +83,7 @@ public abstract class CreativeInventoryScreenMixin extends AbstractInventoryScre
 
 	@Inject(at = @At("HEAD"), method = "removed")
 	private void removed(CallbackInfo info) {
-		TrinketScreenManager.removeSelections();
+		TrinketScreenManager.close();
 	}
 
 	@Inject(at = @At("TAIL"), method = "handledScreenTick")

--- a/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
@@ -43,7 +43,7 @@ public abstract class HandledScreenMixin extends Screen {
 	@Inject(at = @At("HEAD"), method = "removed")
 	private void removed(CallbackInfo info) {
 		if ((Object)this instanceof InventoryScreen) {
-			TrinketScreenManager.removeSelections();
+			TrinketScreenManager.close();
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
@@ -2,6 +2,7 @@ package dev.emi.trinkets.mixin;
 
 import net.minecraft.client.gui.DrawContext;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -27,6 +28,8 @@ import net.minecraft.screen.slot.Slot;
  */
 @Mixin(InventoryScreen.class)
 public abstract class InventoryScreenMixin extends AbstractInventoryScreen<PlayerScreenHandler> implements RecipeBookProvider, TrinketScreen {
+
+	@Shadow private boolean narrow;
 
 	private InventoryScreenMixin() { super(null, null, null); }
 
@@ -94,5 +97,10 @@ public abstract class InventoryScreenMixin extends AbstractInventoryScreen<Playe
 	@Override
 	public boolean trinkets$isRecipeBookOpen() {
 		return this.getRecipeBookWidget().isOpen();
+	}
+
+	@Override
+	public boolean trinkets$isNarrow() {
+		return this.narrow;
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import net.minecraft.registry.tag.ItemTags;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -29,7 +28,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.attribute.AttributeContainer;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
@@ -145,25 +143,29 @@ public abstract class LivingEntityMixin extends Entity {
 					TrinketsApi.getTrinket(oldStack.getItem()).onUnequip(oldStack, ref, entity);
 					TrinketsApi.getTrinket(newStack.getItem()).onEquip(newStack, ref, entity);
 
-					if (!this.getWorld().isClient  && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinkets) {
+					if (!this.getWorld().isClient && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinkets) {
 						contentUpdates.put(newRef, newStackCopy);
 
 						if (!oldStack.isEmpty()) {
 							livingEntityTrinkets.removeSlotModifiers(oldStack, ref);
 						}
 
-						if (!newStack.isEmpty()) {
+						if (!newStack.isEmpty() && index < inventory.size()) {
 							livingEntityTrinkets.addSlotModifiers(newStack, ref);
 						}
 					}
 				}
-				TrinketsApi.getTrinket(newStack.getItem()).tick(newStack, ref, entity);
-				ItemStack tickedStack = inventory.getStack(index);
-				// Avoid calling equip/unequip on stacks that mutate themselves
-				if (tickedStack.getItem() == newStackCopy.getItem()) {
-					newlyEquippedTrinkets.put(newRef, tickedStack.copy());
-				} else {
-					newlyEquippedTrinkets.put(newRef, newStackCopy);
+
+				// Check that the inventory hasn't shrunk past the new stack
+				if (index < inventory.size()) {
+					TrinketsApi.getTrinket(newStack.getItem()).tick(newStack, ref, entity);
+					ItemStack tickedStack = inventory.getStack(index);
+					// Avoid calling equip/unequip on stacks that mutate themselves
+					if (tickedStack.getItem() == newStackCopy.getItem()) {
+						newlyEquippedTrinkets.put(newRef, tickedStack.copy());
+					} else {
+						newlyEquippedTrinkets.put(newRef, newStackCopy);
+					}
 				}
 			});
 

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -146,13 +146,7 @@ public abstract class LivingEntityMixin extends Entity {
 					if (!this.getWorld().isClient && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinkets) {
 						contentUpdates.put(newRef, newStackCopy);
 
-						if (!oldStack.isEmpty()) {
-							livingEntityTrinkets.removeSlotModifiers(oldStack, ref);
-						}
-
-						if (!newStack.isEmpty() && index < inventory.size()) {
-							livingEntityTrinkets.addSlotModifiers(newStack, ref);
-						}
+						livingEntityTrinkets.processSlotModifiers(ref, oldStack, newStack);
 					}
 				}
 

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -27,6 +27,7 @@ import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketEnums.DropRule;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import dev.emi.trinkets.api.event.TrinketDropCallback;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
@@ -161,22 +162,8 @@ public abstract class LivingEntityMixin extends Entity {
 						contentUpdates.put(newRef, newStackCopy);
 						UUID uuid = SlotAttributes.getUuid(ref);
 
-						if (!oldStack.isEmpty()) {
-							Trinket trinket = TrinketsApi.getTrinket(oldStack.getItem());
-							Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(oldStack, ref, entity, uuid);
-							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
-							Set<SlotEntityAttribute> toRemove = Sets.newHashSet();
-							for (EntityAttribute attr : map.keySet()) {
-								if (attr instanceof SlotEntityAttribute slotAttr) {
-									slotMap.putAll(slotAttr.slot, map.get(attr));
-									toRemove.add(slotAttr);
-								}
-							}
-							for (SlotEntityAttribute attr : toRemove) {
-								map.removeAll(attr);
-							}
-							this.getAttributes().removeModifiers(map);
-							trinkets.removeModifiers(slotMap);
+						if (!oldStack.isEmpty() && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
+							livingEntityTrinketComponent.clearSlotModifiers(oldStack, ref);
 						}
 
 						if (!newStack.isEmpty()) {

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -3,12 +3,8 @@ package dev.emi.trinkets.mixin;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
-
+import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import net.minecraft.registry.tag.ItemTags;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,14 +16,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.emi.trinkets.TrinketsNetwork;
-import dev.emi.trinkets.api.SlotAttributes;
-import dev.emi.trinkets.api.SlotAttributes.SlotEntityAttribute;
 import dev.emi.trinkets.api.SlotType;
-import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketEnums.DropRule;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
-import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import dev.emi.trinkets.api.event.TrinketDropCallback;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
@@ -38,8 +30,6 @@ import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.AttributeContainer;
-import net.minecraft.entity.attribute.EntityAttribute;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
@@ -57,9 +47,6 @@ import net.minecraft.world.GameRules;
 public abstract class LivingEntityMixin extends Entity {
 	@Unique
 	private final Map<String, ItemStack> lastEquippedTrinkets = new HashMap<>();
-	
-	@Shadow
-	protected abstract AttributeContainer getAttributes();
 
 	private LivingEntityMixin() {
 		super(null, null);
@@ -158,30 +145,15 @@ public abstract class LivingEntityMixin extends Entity {
 					TrinketsApi.getTrinket(oldStack.getItem()).onUnequip(oldStack, ref, entity);
 					TrinketsApi.getTrinket(newStack.getItem()).onEquip(newStack, ref, entity);
 
-					if (!this.getWorld().isClient) {
+					if (!this.getWorld().isClient  && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinkets) {
 						contentUpdates.put(newRef, newStackCopy);
-						UUID uuid = SlotAttributes.getUuid(ref);
 
-						if (!oldStack.isEmpty() && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-							livingEntityTrinketComponent.clearSlotModifiers(oldStack, ref);
+						if (!oldStack.isEmpty()) {
+							livingEntityTrinkets.removeSlotModifiers(oldStack, ref);
 						}
 
 						if (!newStack.isEmpty()) {
-							Trinket trinket = TrinketsApi.getTrinket(newStack.getItem());
-							Multimap<EntityAttribute, EntityAttributeModifier> map = trinket.getModifiers(newStack, ref, entity, uuid);
-							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
-							Set<SlotEntityAttribute> toRemove = Sets.newHashSet();
-							for (EntityAttribute attr : map.keySet()) {
-								if (attr instanceof SlotEntityAttribute slotAttr) {
-									slotMap.putAll(slotAttr.slot, map.get(attr));
-									toRemove.add(slotAttr);
-								}
-							}
-							for (SlotEntityAttribute attr : toRemove) {
-								map.removeAll(attr);
-							}
-							this.getAttributes().addTemporaryModifiers(map);
-							trinkets.addTemporaryModifiers(slotMap);
+							livingEntityTrinkets.addSlotModifiers(newStack, ref);
 						}
 					}
 				}

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -186,6 +186,9 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 
 					for (ServerPlayerEntity player : PlayerLookup.tracking(entity)) {
 						ServerPlayNetworking.send(player, TrinketsNetwork.SYNC_INVENTORY, buf);
+						if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
+							screenHandler.trinkets$updateTrinketSlots(false);
+						}
 					}
 
 					if (entity instanceof ServerPlayerEntity serverPlayer) {

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.event.SlotCountModificationCallback;
 import net.minecraft.registry.tag.ItemTags;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -163,9 +164,9 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 				}
 			});
 
-			if (!this.getWorld().isClient) {
-				Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
+			Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
 
+			if (!this.getWorld().isClient) {
 				if (!contentUpdates.isEmpty() || !inventoriesToSend.isEmpty()) {
 					PacketByteBuf buf = PacketByteBufs.create();
 					buf.writeInt(entity.getId());
@@ -186,9 +187,6 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 
 					for (ServerPlayerEntity player : PlayerLookup.tracking(entity)) {
 						ServerPlayNetworking.send(player, TrinketsNetwork.SYNC_INVENTORY, buf);
-						if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
-							screenHandler.trinkets$updateTrinketSlots(false);
-						}
 					}
 
 					if (entity instanceof ServerPlayerEntity serverPlayer) {
@@ -198,10 +196,14 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 							((TrinketPlayerScreenHandler) serverPlayer.playerScreenHandler).trinkets$updateTrinketSlots(false);
 						}
 					}
-
-					inventoriesToSend.clear();
 				}
 			}
+
+			if (!inventoriesToSend.isEmpty()) {
+				SlotCountModificationCallback.EVENT.invoker().onChange(trinkets, inventoriesToSend);
+			}
+
+			inventoriesToSend.clear();
 
 			lastEquippedTrinkets.clear();
 			lastEquippedTrinkets.putAll(newlyEquippedTrinkets);

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
+import dev.emi.trinkets.api.SlotReference;
 import net.minecraft.registry.tag.ItemTags;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
@@ -42,7 +43,7 @@ import net.minecraft.world.GameRules;
  * @author Emi
  */
 @Mixin(LivingEntity.class)
-public abstract class LivingEntityMixin extends Entity {
+public abstract class LivingEntityMixin extends Entity implements LivingEntityTrinketComponent.StackHistory {
 	@Unique
 	private final Map<String, ItemStack> lastEquippedTrinkets = new HashMap<>();
 
@@ -131,12 +132,11 @@ public abstract class LivingEntityMixin extends Entity {
 			Map<String, ItemStack> contentUpdates = new HashMap<>();
 			trinkets.forEach((ref, stack) -> {
 				TrinketInventory inventory = ref.inventory();
-				SlotType slotType = inventory.getSlotType();
 				int index = ref.index();
-				ItemStack oldStack = getOldStack(slotType, index);
+				ItemStack oldStack = trinkets$getOldStack(ref);
 				ItemStack newStack = inventory.getStack(index);
 				ItemStack newStackCopy = newStack.copy();
-				String newRef = slotType.getGroup() + "/" + slotType.getName() + "/" + index;
+				String newRef = ref.getId();
 
 				if (!ItemStack.areEqual(newStack, oldStack)) {
 
@@ -205,8 +205,8 @@ public abstract class LivingEntityMixin extends Entity {
 		});
 	}
 
-	@Unique
-	private ItemStack getOldStack(SlotType type, int index) {
-		return lastEquippedTrinkets.getOrDefault(type.getGroup() + "/" + type.getName() + "/" + index, ItemStack.EMPTY);
+	@Override
+	public ItemStack trinkets$getOldStack(SlotReference ref) {
+		return lastEquippedTrinkets.getOrDefault(ref.getId(), ItemStack.EMPTY);
 	}
 }


### PR DESCRIPTION
This PR was initially intended to be relatively minor, but we kept bumping against related issues to fix. If splitting this into several PRs would be preferable, we can attempt to do so.

First, the methods for adding and removing attribute modifiers of a stack that has been unequipped was moved out of the LivingEntityMixin; This allows it to be called by the TrinketComponent refresh for inventory size changes and the Inventory Update function for when a slot modification causes *another* slot-modifying trinket to drop, additionally calling the relevant onUnequip method. Previously, if a trinket would drop from slot modification, then it's attributes would remain.

_As such, you could equip a trinket in the ring/0 slot that gives +1 ring slot, equip another in ring/1, and a third in ring/2. Removing ring/0 will still leave three ring slots, so no items would drop, down from the 4 you'd have with all three equipped. Removing ring/1 will reduce the slot count to 2, meaning that ring/2 will be dropped upon Inventory Update. However, without this change, ring/2's +1 ring slot removal would not process, leaving the player with 2 ring slots. Now, if the bottom 'block of the Jenga Tower' is removed, all the above 'blocks' will come crashing down too, instead of staying in place mid-air._

The two private methods were also merged, so as to allow a self-supporting trinket to be swapped in-place.

An additional check was added to the equipment change checks to not attempt to tick an item that has been removed from a slot which it supports - as said slot will no longer exist by the time that section of the method is reached, causing a crash.

Whilst not directly related to slot modification not being processed, MC-272769 was mitigated by adding a check upon unequipping an item with a static, non-slot-modified UUID intended to be exclusive. This checks that no other trinkets equipped have that attribute modifier before removing it, preventing the case where, if two trinkets are equipped with an attribute with the same UUID so as to not layer the effect, and one of them is removed, then the attribute is removed even though another trinket exists which provides that same attribute modifier UUID. ( Non-layerable UUIDs are presumed to be intended from here: https://github.com/emilyploszaj/trinkets/pull/320#discussion_r1649467685 )

One of the main issues with recursively modifying slot attributes, and therefore modifying the inventory, is that slot modification will mark an update, and any access to the inventory will run an update if marked, resulting in, if operation A would cause operation B to be run, for operation B to run *before* operation A's modifications would be saved as the inventory, meaning B's changes are overwritten when A resolves, and B doesn't see A's changes. As such, if update() is called mid-update, the update is suppressed until the outer update has resolved, at which point, it's triggered. This essentially turns a nesting-doll of resolves that never benefit from each other into tail-end recursion, resolving in a series in the order by which the operations are called. This ensures all modifications are kept, and taken into account, instead of being dropped or not detected.

Whilst also not directly related to slot count modification, if a trinkets slot is in a group with enough slots to extend past the natural trinket bounds, then it's considered as *outside* the bounds - therefore, left clicks will cause one item of that stack to be dropped, instead of the slot being naturally interactable. A trinket slot is now considered to be within trinket bounds, even if it extends past the static slots, to resolve this issue. If the number of slots in a slot type currently hovered over changes, the bounds are cleared, causing them to be recalculated once to check to see if the area has changed, meaning that the slot type doesn't need to be re-hovered in order to access slots previously outside the bounds, and that slots that no longer exist won't occlude slots beneath. Finally, the recipe book previously had uninteractable areas where trinket slots lay if the screen was in narrow mode - this has also been resolved.

In order to more easily achieve the above, a modified version @Ampflower's commit to the Main branch was merged into this one, which should also resolve the memory leaks, using the initial idea for the implementation due to other mods relying on the field type in this version.

Recursive updates were changed to use the old stacks present, as the method in LivingEntityMixin does, through the interface LivingEntityTrinketComponent.StackHistory. A list of dropped stacks is kept in the update method of a LivingEntityTrinketComponent whilst it processes items dropped, so as to modify the new inventory when processing Attribute Modifiers and onUnequips, and removed slots will also attempt to drop their items. Due to the potential for odd behaviour in onUnequip implementations acting upon a slotType that no longer exists, that section is in a try-catch block.

I am certain that large sections of this do not adhere to the style of the mod, and will gladly refactor to improve code quality if needed. There are quite likely some crashes and strange behaviours that have been overlooked, but after some testing and finding none, hopefully they are far less consequential or harder to trigger than the ones that this PR fixes? I have attempted to maintain compatibility, additionally, and have attempted to avoid changes to method signatures that may be accessed by other mods. The main method changed, the private methods in LivingEntityMixin, *shouldn't* be directly referenced by other mods, and, additionally, is not in the API package, so our assumption is that those were safe to change. If we need to elaborate on any points here, we would be more than happy to do so.

~~**NOTE**: When building locally, lambda identifiers are swapped from 3.7.2 - e.g. lambda$render$2 and lambda$render$0 are swapped in TrinketFeatureRenderer. This breaks PeculiarPieces and TrinkHide, for example.~~ Resolved via clean build.