### PR TITLE
1.21.5  Slot Modification and GUI fixes

### DIFF
--- a/src/main/java/dev/emi/trinkets/TrinketScreen.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreen.java
@@ -20,6 +20,10 @@ public interface TrinketScreen {
 		return false;
 	}
 
+	public default boolean trinkets$isNarrow() {
+		return false;
+	}
+
 	public default void trinkets$updateTrinketSlots() {
 	}
 }

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -346,6 +346,10 @@ public class TrinketScreenManager {
 		}
 
 		TrinketPlayerScreenHandler handler = currentScreen.trinkets$getHandler();
+		if (currentScreen.trinkets$getFocusedSlot() instanceof TrinketSlot) {
+			return true;
+		}
+
 		int x = currentScreen.trinkets$getX();
 		int y = currentScreen.trinkets$getY();
 		int mx = (int) (Math.round(mouseX) - x);

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -53,7 +53,17 @@ public class TrinketScreenManager {
 		if (group != null) {
 			if (TrinketsClient.activeType != null) {
 				if (!typeBounds.contains(Math.round(mouseX) - x, Math.round(mouseY) - y)) {
-					TrinketsClient.activeType = null;
+					// Attempt to refresh the typeBounds, in case the slot count has changed.
+					int i = handler.trinkets$getSlotTypes(group).indexOf(TrinketsClient.activeType);
+					if (i >= 0) {
+						Rect2i r = currentScreen.trinkets$getGroupRect(group);
+						Point slotHeight = handler.trinkets$getSlotHeight(group, i);
+						int height = slotHeight.y();
+						typeBounds = new Rect2i(r.getX() + slotHeight.x() - 2, r.getY() - (height - 1) / 2 * 18 - 3, 23, height * 18 + 5);
+					}
+					if (!typeBounds.contains(Math.round(mouseX) - x, Math.round(mouseY) - y)) {
+						TrinketsClient.activeType = null;
+					}
 				} else if (focusedSlot != null) {
 					if (!(focusedSlot instanceof TrinketSlot ts && ts.getType() == TrinketsClient.activeType)) {
 						TrinketsClient.activeType = null;
@@ -380,6 +390,8 @@ public class TrinketScreenManager {
 		TrinketScreen currentScreen = getCurrentScreen();
 
 		if (currentScreen != null) {
+			// Refresh the type bounds of the currently open Trinket Group on slot change.
+			typeBounds = new Rect2i(0, 0, 0, 0);
 			currentScreen.trinkets$updateTrinketSlots();
 		}
 	}

--- a/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
+++ b/src/main/java/dev/emi/trinkets/TrinketScreenManager.java
@@ -8,6 +8,7 @@ import com.mojang.blaze3d.opengl.GlStateManager;
 import dev.emi.trinkets.api.SlotGroup;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.mixin.accessor.RecipeBookScreenAccessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.render.RenderLayer;
@@ -123,9 +124,11 @@ public class TrinketScreenManager {
 					continue;
 				}
 				if (r.contains(Math.round(mouseX) - x, Math.round(mouseY) - y)) {
-					TrinketsClient.activeGroup = g;
-					TrinketsClient.quickMoveGroup = null;
-					break;
+					if (!(currentScreen.trinkets$isNarrow() && currentScreen.trinkets$isRecipeBookOpen())) {
+						TrinketsClient.activeGroup = g;
+						TrinketsClient.quickMoveGroup = null;
+						break;
+					}
 				}
 			}
 		}

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -7,6 +7,7 @@ import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.data.EntitySlotLoader;
+import dev.emi.trinkets.api.TrinketComponent;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.MinecraftClient;
@@ -84,6 +85,12 @@ public class TrinketsClient implements ClientModInitializer {
 				for (AbstractClientPlayerEntity clientWorldPlayer : player.clientWorld.getPlayers()) {
 					((TrinketPlayerScreenHandler) clientWorldPlayer.playerScreenHandler).trinkets$updateTrinketSlots(true);
 				}
+
+                for (Entity clientWorldEntity : player.clientWorld.getEntities()) {
+                    if (clientWorldEntity instanceof LivingEntity livingEntity) {
+                        TrinketsApi.getTrinketComponent(livingEntity).ifPresent(TrinketComponent::update);
+                    }
+                }
 			}
 
 		});

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -51,10 +51,7 @@ public class TrinketsClient implements ClientModInitializer {
 					if (entity instanceof PlayerEntity && ((PlayerEntity) entity).playerScreenHandler instanceof TrinketPlayerScreenHandler screenHandler) {
 						screenHandler.trinkets$updateTrinketSlots(false);
 						TrinketScreenManager.tryUpdateTrinketsSlot();
-					} else if (client.player != null && client.player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(client.player.playerScreenHandler)) {
-                        screenHandler.trinkets$updateTrinketSlots(false);
-                        TrinketScreenManager.tryUpdateTrinketsSlot();
-                    }
+					}
 
 					for (Map.Entry<String, ItemStack> entry : payload.contentUpdates().entrySet()) {
 						String[] split = entry.getKey().split("/");

--- a/src/main/java/dev/emi/trinkets/TrinketsClient.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsClient.java
@@ -51,7 +51,10 @@ public class TrinketsClient implements ClientModInitializer {
 					if (entity instanceof PlayerEntity && ((PlayerEntity) entity).playerScreenHandler instanceof TrinketPlayerScreenHandler screenHandler) {
 						screenHandler.trinkets$updateTrinketSlots(false);
 						TrinketScreenManager.tryUpdateTrinketsSlot();
-					}
+					} else if (client.player != null && client.player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(client.player.playerScreenHandler)) {
+                        screenHandler.trinkets$updateTrinketSlots(false);
+                        TrinketScreenManager.tryUpdateTrinketsSlot();
+                    }
 
 					for (Map.Entry<String, ItemStack> entry : payload.contentUpdates().entrySet()) {
 						String[] split = entry.getKey().split("/");
@@ -90,6 +93,11 @@ public class TrinketsClient implements ClientModInitializer {
                     if (clientWorldEntity instanceof LivingEntity livingEntity) {
                         TrinketsApi.getTrinketComponent(livingEntity).ifPresent(TrinketComponent::update);
                     }
+                }
+
+                if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
+                    screenHandler.trinkets$updateTrinketSlots(false);
+                    TrinketScreenManager.tryUpdateTrinketsSlot();
                 }
 			}
 

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -16,6 +16,9 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Identifier;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -52,8 +55,10 @@ public class TrinketsMain implements ModInitializer, EntityComponentInitializer 
 		ResourceManagerHelper resourceManagerHelper = ResourceManagerHelper.get(ResourceType.SERVER_DATA);
 		resourceManagerHelper.registerReloadListener(SlotLoader.INSTANCE);
 		resourceManagerHelper.registerReloadListener(EntitySlotLoader.SERVER);
-		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success)
-				-> EntitySlotLoader.SERVER.sync(server.getPlayerManager().getPlayerList()));
+		ServerLifecycleEvents.END_DATA_PACK_RELOAD.register((server, serverResourceManager, success) -> {
+			EntitySlotLoader.SERVER.sync(server.getPlayerManager().getPlayerList());
+			EntitySlotLoader.SERVER.updateEntities(server);
+		});
 		UseItemCallback.EVENT.register((player, world, hand) -> {
 			ItemStack stack = player.getStackInHand(hand);
 			Trinket trinket = TrinketsApi.getTrinket(stack.getItem());

--- a/src/main/java/dev/emi/trinkets/TrinketsMain.java
+++ b/src/main/java/dev/emi/trinkets/TrinketsMain.java
@@ -6,6 +6,7 @@ import static net.minecraft.server.command.CommandManager.argument;
 import static net.minecraft.server.command.CommandManager.literal;
 
 import dev.emi.trinkets.api.*;
+import dev.emi.trinkets.api.event.SlotCountModificationCallback;
 import dev.emi.trinkets.payload.BreakPayload;
 import dev.emi.trinkets.payload.SyncInventoryPayload;
 import dev.emi.trinkets.payload.SyncSlotsPayload;

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Sets;
 import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.emi.trinkets.api.SlotAttributes.SlotEntityAttribute;
+import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.registry.RegistryWrapper;
@@ -89,12 +90,16 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
-								this.processSlotModifiers(new SlotReference(oldInv, i), stack, ItemStack.EMPTY);
+								SlotReference ref = new SlotReference(oldInv, i);
+								this.processSlotModifiers(ref, stack, ItemStack.EMPTY);
+								TrinketsApi.getTrinket(stack.getItem()).onUnequip(stack, ref, entity);
+								TrinketUnequipCallback.EVENT.invoker().onUnequip(stack, ref, entity);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else if (this.entity.getWorld() instanceof ServerWorld serverWorld) {
 									this.entity.dropStack(serverWorld, stack);
 								}
+								ref.set(ItemStack.EMPTY);
 							}
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -431,4 +431,10 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 			}
 		}
 	}
+
+	public interface StackHistory {
+		default ItemStack trinkets$getOldStack(SlotReference ref) {
+			return ItemStack.EMPTY;
+		}
+	}
 }

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -209,11 +209,19 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		for (RegistryEntry<EntityAttribute> attr : toRemove) {
 			map.removeAll(attr);
 		}
+		// MC-272769 Mitigation.
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
+		this.forEach(((slotReference, itemStack) -> {
+			if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
+				existsElsewhere.putAll(TrinketModifiers.get(itemStack, slotReference, entity));
+			}
+		}));
+		existsElsewhere.forEach(map::remove);
 		//this.getEntity().getAttributes().removeModifiers(map);
 		map.asMap().forEach((attribute, modifiers) -> {
 			EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);
 			if (entityAttributeInstance != null) {
-				modifiers.forEach(modifier -> entityAttributeInstance.removeModifier(modifier.id()));
+				modifiers.forEach(modifier -> entityAttributeInstance.removeModifier(modifier.id()) );
 			}
 		});
 

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -89,7 +89,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
-								this.removeSlotModifiers(stack, new SlotReference(oldInv, i));
+								this.processSlotModifiers(new SlotReference(oldInv, i), stack, ItemStack.EMPTY);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else if (this.entity.getWorld() instanceof ServerWorld serverWorld) {
@@ -196,9 +196,10 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 	}
 
-	public void removeSlotModifiers(ItemStack stack, SlotReference ref) {
-		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
-		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+	public void processSlotModifiers(SlotReference ref, ItemStack oldStack, ItemStack newStack) {
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> removeModifiers = TrinketModifiers.get(oldStack, ref, entity);
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> addModifiers = TrinketModifiers.get(newStack, ref, entity);
+		Multimap<String, EntityAttributeModifier> removeSlotMap = HashMultimap.create(), addSlotMap = HashMultimap.create();
 
         // MC-272769 Mitigation.
         Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
@@ -207,52 +208,44 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
                 existsElsewhere.putAll(TrinketModifiers.get(itemStack, slotReference, entity));
             }
         }));
-        existsElsewhere.forEach(map::remove);
+        existsElsewhere.forEach(removeModifiers::remove);
 
 		Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
-		for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
+		for (RegistryEntry<EntityAttribute> attr : removeModifiers.keySet()) {
 			if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
-				slotMap.putAll(slotAttr.slot, map.get(attr));
+				removeSlotMap.putAll(slotAttr.slot, removeModifiers.get(attr));
 				toRemove.add(attr);
 			}
 		}
+        for (RegistryEntry<EntityAttribute> attr : addModifiers.keySet()) {
+            if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
+                addSlotMap.putAll(slotAttr.slot, addModifiers.get(attr));
+                toRemove.add(attr);
+            }
+        }
+
 		for (RegistryEntry<EntityAttribute> attr : toRemove) {
-			map.removeAll(attr);
+			removeModifiers.removeAll(attr);
+            addModifiers.removeAll(attr);
 		}
 		//this.getEntity().getAttributes().removeModifiers(map);
-		map.asMap().forEach((attribute, modifiers) -> {
+		removeModifiers.asMap().forEach((attribute, modifiers) -> {
 			EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);
 			if (entityAttributeInstance != null) {
 				modifiers.forEach(modifier -> entityAttributeInstance.removeModifier(modifier.id()) );
 			}
 		});
+        //this.getEntity().getAttributes().addTemporaryModifiers(map);
+        addModifiers.forEach((attribute, attributeModifier) -> {
+            EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);
+            if (entityAttributeInstance != null) {
+                entityAttributeInstance.removeModifier(attributeModifier.id());
+                entityAttributeInstance.addTemporaryModifier(attributeModifier);
+            }
 
-		this.removeModifiers(slotMap);
-	}
-
-	public void addSlotModifiers(ItemStack stack, SlotReference ref) {
-		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
-		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
-		Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
-		for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
-			if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
-				slotMap.putAll(slotAttr.slot, map.get(attr));
-				toRemove.add(attr);
-			}
-		}
-		for (RegistryEntry<EntityAttribute> attr : toRemove) {
-			map.removeAll(attr);
-		}
-		//this.getEntity().getAttributes().addTemporaryModifiers(map);
-		map.forEach((attribute, attributeModifier) -> {
-			EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);
-			if (entityAttributeInstance != null) {
-				entityAttributeInstance.removeModifier(attributeModifier.id());
-				entityAttributeInstance.addTemporaryModifier(attributeModifier);
-			}
-
-		});
-		this.addTemporaryModifiers(slotMap);
+        });
+        this.removeModifiers(removeSlotMap);
+        this.addTemporaryModifiers(addSlotMap);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -17,6 +17,7 @@ import com.google.common.collect.Sets;
 
 import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
+import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.api.SlotAttributes.SlotEntityAttribute;
 import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
@@ -98,7 +99,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 								}
 								droppedItems.put(ref, oldStack);
 								if (this.entity instanceof PlayerEntity player) {
-									player.getInventory().offerOrDrop(stack);
+									player.getInventory().offerOrDrop(stack.copy());
 								} else if (this.entity.getWorld() instanceof ServerWorld serverWorld) {
 									this.entity.dropStack(serverWorld, stack);
 								}
@@ -110,13 +111,31 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 				count += inv.size();
 			}
 		}
+
+		// Handle dropping newly slotless items.
+		forEach((ref, itemStack) -> {
+			if (!groups.containsKey(ref.getSlotType().getGroup()) || !groups.get(ref.getSlotType().getGroup()).getSlots().containsKey(ref.getSlotType().getName())) {
+				droppedItems.put(ref, itemStack);
+				if (this.entity instanceof PlayerEntity player) {
+					player.getInventory().offerOrDrop(itemStack.copy());
+				} else if (this.entity.getWorld() instanceof ServerWorld serverWorld) {
+					this.entity.dropStack(serverWorld, itemStack);
+				}
+			}
+		});
+
 		size = count;
 		this.inventory = inventory;
+
 		for (Map.Entry<SlotReference, ItemStack> dropped : droppedItems.entrySet()) {
-			this.processSlotModifiers(dropped.getKey(), dropped.getValue(), ItemStack.EMPTY);
-			TrinketsApi.getTrinket(dropped.getValue().getItem()).onUnequip(dropped.getValue(), dropped.getKey(), entity);
-			TrinketUnequipCallback.EVENT.invoker().onUnequip(dropped.getValue(), dropped.getKey(), entity);
-			dropped.getKey().set(ItemStack.EMPTY);
+			try {
+				this.processSlotModifiers(dropped.getKey(), dropped.getValue(), ItemStack.EMPTY);
+				TrinketsApi.getTrinket(dropped.getValue().getItem()).onUnequip(dropped.getValue(), dropped.getKey(), entity);
+				TrinketUnequipCallback.EVENT.invoker().onUnequip(dropped.getValue(), dropped.getKey(), entity);
+				dropped.getKey().set(ItemStack.EMPTY);
+			} catch (Exception e) {
+				TrinketsMain.LOGGER.warn("Caught exception when dropping {} from removed slot {}.", dropped.getValue(), dropped.getKey().getId());
+			}
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -13,9 +13,12 @@ import java.util.function.Predicate;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 
 import dev.emi.trinkets.TrinketModifiers;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
+import dev.emi.trinkets.api.SlotAttributes.SlotEntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.registry.entry.RegistryEntry;
@@ -86,6 +89,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 							if (i < inv.size()) {
 								inv.setStack(i, stack);
 							} else {
+								this.removeSlotModifiers(stack, new SlotReference(oldInv, i));
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else if (this.entity.getWorld() instanceof ServerWorld serverWorld) {
@@ -190,6 +194,55 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 				slotType.getValue().clearModifiers();
 			}
 		}
+	}
+
+	public void removeSlotModifiers(ItemStack stack, SlotReference ref) {
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
+		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+		Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
+		for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
+			if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
+				slotMap.putAll(slotAttr.slot, map.get(attr));
+				toRemove.add(attr);
+			}
+		}
+		for (RegistryEntry<EntityAttribute> attr : toRemove) {
+			map.removeAll(attr);
+		}
+		//this.getEntity().getAttributes().removeModifiers(map);
+		map.asMap().forEach((attribute, modifiers) -> {
+			EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);
+			if (entityAttributeInstance != null) {
+				modifiers.forEach(modifier -> entityAttributeInstance.removeModifier(modifier.id()));
+			}
+		});
+
+		this.removeModifiers(slotMap);
+	}
+
+	public void addSlotModifiers(ItemStack stack, SlotReference ref) {
+		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
+		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+		Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
+		for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
+			if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
+				slotMap.putAll(slotAttr.slot, map.get(attr));
+				toRemove.add(attr);
+			}
+		}
+		for (RegistryEntry<EntityAttribute> attr : toRemove) {
+			map.removeAll(attr);
+		}
+		//this.getEntity().getAttributes().addTemporaryModifiers(map);
+		map.forEach((attribute, attributeModifier) -> {
+			EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);
+			if (entityAttributeInstance != null) {
+				entityAttributeInstance.removeModifier(attributeModifier.id());
+				entityAttributeInstance.addTemporaryModifier(attributeModifier);
+			}
+
+		});
+		this.addTemporaryModifiers(slotMap);
 	}
 
 	@Override

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -73,6 +73,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		Map<String, SlotGroup> entitySlots = TrinketsApi.getEntitySlots(this.entity);
 		int count = 0;
 		groups.clear();
+		Map<SlotReference, ItemStack> droppedItems = new HashMap<>();
 		Map<String, Map<String, TrinketInventory>> inventory = new HashMap<>();
 		for (Map.Entry<String, SlotGroup> group : entitySlots.entrySet()) {
 			String groupKey = group.getKey();
@@ -91,15 +92,16 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 								inv.setStack(i, stack);
 							} else {
 								SlotReference ref = new SlotReference(oldInv, i);
-								this.processSlotModifiers(ref, stack, ItemStack.EMPTY);
-								TrinketsApi.getTrinket(stack.getItem()).onUnequip(stack, ref, entity);
-								TrinketUnequipCallback.EVENT.invoker().onUnequip(stack, ref, entity);
+								ItemStack oldStack = stack;
+								if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory) {
+									oldStack = stackHistory.trinkets$getOldStack(ref);
+								}
+								droppedItems.put(ref, oldStack);
 								if (this.entity instanceof PlayerEntity player) {
 									player.getInventory().offerOrDrop(stack);
 								} else if (this.entity.getWorld() instanceof ServerWorld serverWorld) {
 									this.entity.dropStack(serverWorld, stack);
 								}
-								ref.set(ItemStack.EMPTY);
 							}
 						}
 					}
@@ -110,6 +112,12 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		}
 		size = count;
 		this.inventory = inventory;
+		for (Map.Entry<SlotReference, ItemStack> dropped : droppedItems.entrySet()) {
+			this.processSlotModifiers(dropped.getKey(), dropped.getValue(), ItemStack.EMPTY);
+			TrinketsApi.getTrinket(dropped.getValue().getItem()).onUnequip(dropped.getValue(), dropped.getKey(), entity);
+			TrinketUnequipCallback.EVENT.invoker().onUnequip(dropped.getValue(), dropped.getKey(), entity);
+			dropped.getKey().set(ItemStack.EMPTY);
+		}
 	}
 
 	@Override
@@ -209,7 +217,7 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
         // MC-272769 Mitigation.
         Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
         this.forEach(((slotReference, itemStack) -> {
-            if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
+            if (!(slotReference.getSlotType().equals(ref.getSlotType()) && slotReference.index() == ref.index()) && !itemStack.isEmpty()) {
                 existsElsewhere.putAll(TrinketModifiers.get(itemStack, slotReference, entity));
             }
         }));

--- a/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
+++ b/src/main/java/dev/emi/trinkets/api/LivingEntityTrinketComponent.java
@@ -199,6 +199,16 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 	public void removeSlotModifiers(ItemStack stack, SlotReference ref) {
 		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(stack, ref, entity);
 		Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
+
+        // MC-272769 Mitigation.
+        Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
+        this.forEach(((slotReference, itemStack) -> {
+            if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
+                existsElsewhere.putAll(TrinketModifiers.get(itemStack, slotReference, entity));
+            }
+        }));
+        existsElsewhere.forEach(map::remove);
+
 		Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
 		for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
 			if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
@@ -209,14 +219,6 @@ public class LivingEntityTrinketComponent implements TrinketComponent, AutoSynce
 		for (RegistryEntry<EntityAttribute> attr : toRemove) {
 			map.removeAll(attr);
 		}
-		// MC-272769 Mitigation.
-		Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> existsElsewhere = HashMultimap.create();
-		this.forEach(((slotReference, itemStack) -> {
-			if (!slotReference.equals(ref) && !itemStack.isEmpty()) {
-				existsElsewhere.putAll(TrinketModifiers.get(itemStack, slotReference, entity));
-			}
-		}));
-		existsElsewhere.forEach(map::remove);
 		//this.getEntity().getAttributes().removeModifiers(map);
 		map.asMap().forEach((attribute, modifiers) -> {
 			EntityAttributeInstance entityAttributeInstance = this.getEntity().getAttributes().getCustomInstance(attribute);

--- a/src/main/java/dev/emi/trinkets/api/SlotReference.java
+++ b/src/main/java/dev/emi/trinkets/api/SlotReference.java
@@ -1,8 +1,23 @@
 package dev.emi.trinkets.api;
 
+import net.minecraft.item.ItemStack;
+
 public record SlotReference(TrinketInventory inventory, int index) {
 
     public String getId() {
         return this.inventory.getSlotType().getId() + "/" + index;
+    }
+
+    public ItemStack get() {
+        return inventory.getStack(index);
+    }
+
+    public boolean set(ItemStack itemStack) {
+        inventory.setStack(index, itemStack);
+        return true;
+    }
+
+    public SlotType getSlotType() {
+        return inventory.getSlotType();
     }
 }

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -183,8 +183,13 @@ public class TrinketInventory implements Inventory {
 					if (i < newStacks.size()) {
 						newStacks.set(i, stack);
 					} else {
+						SlotReference ref = new SlotReference(this, i);
+						ItemStack oldStack = stack;
+						if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory) {
+							oldStack = stackHistory.trinkets$getOldStack(ref);
+						}
 						if (!this.getComponent().getEntity().getWorld().isClient && this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-							livingEntityTrinketComponent.processSlotModifiers(new SlotReference(this, i), stack, ItemStack.EMPTY);
+							livingEntityTrinketComponent.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
 						}
 						if (entity.getWorld() instanceof ServerWorld serverWorld) {
 							entity.dropStack(serverWorld, stack);

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -182,6 +182,9 @@ public class TrinketInventory implements Inventory {
 						newStacks.set(i, stack);
 					} else {
 						if (entity.getWorld() instanceof ServerWorld serverWorld) {
+                            if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
+                                livingEntityTrinketComponent.removeSlotModifiers(stack, new SlotReference(this, i));
+                            }
 							entity.dropStack(serverWorld, stack);
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -183,8 +183,8 @@ public class TrinketInventory implements Inventory {
 					if (i < newStacks.size()) {
 						newStacks.set(i, stack);
 					} else {
-						if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-							livingEntityTrinketComponent.removeSlotModifiers(stack, new SlotReference(this, i));
+						if (!this.getComponent().getEntity().getWorld().isClient && this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
+							livingEntityTrinketComponent.processSlotModifiers(new SlotReference(this, i), stack, ItemStack.EMPTY);
 						}
 						if (entity.getWorld() instanceof ServerWorld serverWorld) {
 							entity.dropStack(serverWorld, stack);

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -3,6 +3,7 @@ package dev.emi.trinkets.api;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.mojang.serialization.Codec;
+import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.player.PlayerEntity;
@@ -188,12 +189,15 @@ public class TrinketInventory implements Inventory {
 						if (entity instanceof LivingEntityTrinketComponent.StackHistory stackHistory) {
 							oldStack = stackHistory.trinkets$getOldStack(ref);
 						}
+						TrinketsApi.getTrinket(oldStack.getItem()).onUnequip(oldStack, ref, entity);
+						TrinketUnequipCallback.EVENT.invoker().onUnequip(oldStack, ref, entity);
 						if (!this.getComponent().getEntity().getWorld().isClient && this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
 							livingEntityTrinketComponent.processSlotModifiers(ref, oldStack, ItemStack.EMPTY);
 						}
 						if (entity.getWorld() instanceof ServerWorld serverWorld) {
 							entity.dropStack(serverWorld, stack);
 						}
+						ref.set(ItemStack.EMPTY);
 					}
 				}
 

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -32,6 +32,7 @@ public class TrinketInventory implements Inventory {
 
 	private DefaultedList<ItemStack> stacks;
 	private boolean update = false;
+	private boolean suppressUpdates = false;
 
 	public TrinketInventory(SlotType slotType, TrinketComponent comp, Consumer<TrinketInventory> updateCallback) {
 		this.component = comp;
@@ -157,8 +158,9 @@ public class TrinketInventory implements Inventory {
 	}
 
 	public void update() {
-		if (this.update) {
+		if (this.update && !suppressUpdates) {
 			this.update = false;
+			this.suppressUpdates = true;
 			double baseSize = this.baseSize;
 			for (EntityAttributeModifier mod : this.getModifiersByOperation(EntityAttributeModifier.Operation.ADD_VALUE)) {
 				baseSize += mod.value();
@@ -192,6 +194,9 @@ public class TrinketInventory implements Inventory {
 
 				this.stacks = newStacks;
 			}
+			// Process updates sequentially, instead of in the middle of an incomplete update.
+			this.suppressUpdates = false;
+			this.update();
 		}
 	}
 

--- a/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
+++ b/src/main/java/dev/emi/trinkets/api/TrinketInventory.java
@@ -181,10 +181,10 @@ public class TrinketInventory implements Inventory {
 					if (i < newStacks.size()) {
 						newStacks.set(i, stack);
 					} else {
+						if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
+							livingEntityTrinketComponent.removeSlotModifiers(stack, new SlotReference(this, i));
+						}
 						if (entity.getWorld() instanceof ServerWorld serverWorld) {
-                            if (this.getComponent() instanceof LivingEntityTrinketComponent livingEntityTrinketComponent) {
-                                livingEntityTrinketComponent.removeSlotModifiers(stack, new SlotReference(this, i));
-                            }
 							entity.dropStack(serverWorld, stack);
 						}
 					}

--- a/src/main/java/dev/emi/trinkets/api/event/SlotCountModificationCallback.java
+++ b/src/main/java/dev/emi/trinkets/api/event/SlotCountModificationCallback.java
@@ -1,0 +1,28 @@
+package dev.emi.trinkets.api.event;
+
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketInventory;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+import java.util.Set;
+
+/**
+ * Event called upon slot modification by attributes.
+ * Does not trigger upon Datapack Reload.
+ */
+
+public interface SlotCountModificationCallback {
+	Event<SlotCountModificationCallback> EVENT = EventFactory.createArrayBacked(SlotCountModificationCallback.class,
+	listeners -> (component, inventories) -> {
+		for (var listener : listeners) {
+			listener.onChange(component, inventories);
+		}
+	});
+
+	/**
+	 * @param component The TrinketComponent the inventories belong to.
+	 * @param inventories A set of inventories affected by EAM modifications.
+	 */
+	void onChange(TrinketComponent component, Set<TrinketInventory> inventories);
+}

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -21,18 +21,30 @@ import com.google.gson.JsonSyntaxException;
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.api.SlotGroup;
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
 import dev.emi.trinkets.data.SlotLoader.GroupData;
 import dev.emi.trinkets.data.SlotLoader.SlotData;
 import dev.emi.trinkets.payload.SyncSlotsPayload;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener;
 import net.fabricmc.fabric.api.resource.ResourceReloadListenerKeys;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.registry.Registries;
 import net.minecraft.resource.Resource;
 import net.minecraft.resource.ResourceManager;
 import net.minecraft.resource.SinglePreparationResourceReloader;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.profiler.Profiler;
@@ -204,6 +216,16 @@ public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<Stri
 		players.forEach(player -> ServerPlayNetworking.send(player, packet));
 		players.forEach(player -> ((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(true));
 	}
+
+    public void updateEntities(MinecraftServer server) {
+        for (ServerWorld world : server.getWorlds()) {
+            for (Entity entity : world.iterateEntities()) {
+                if (entity instanceof LivingEntity livingEntity && !(livingEntity instanceof PlayerEntity)) {
+                    TrinketsApi.getTrinketComponent(livingEntity).ifPresent(TrinketComponent::update);
+                }
+            }
+        }
+    }
 
 	@Override
 	public Identifier getFabricId() {

--- a/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
+++ b/src/main/java/dev/emi/trinkets/data/EntitySlotLoader.java
@@ -215,6 +215,11 @@ public class EntitySlotLoader extends SinglePreparationResourceReloader<Map<Stri
 		SyncSlotsPayload packet = new SyncSlotsPayload(Map.copyOf(this.slots));
 		players.forEach(player -> ServerPlayNetworking.send(player, packet));
 		players.forEach(player -> ((TrinketPlayerScreenHandler) player.playerScreenHandler).trinkets$updateTrinketSlots(true));
+		players.forEach(player -> {
+			if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
+				screenHandler.trinkets$updateTrinketSlots(true);
+			}
+		});
 	}
 
     public void updateEntities(MinecraftServer server) {

--- a/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
@@ -8,7 +8,9 @@ import dev.emi.trinkets.TrinketScreenManager;
 import dev.emi.trinkets.TrinketsMain;
 import dev.emi.trinkets.api.TrinketInventory;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.Element;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.render.RenderLayer;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
@@ -29,6 +31,7 @@ import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.screen.slot.Slot;
 import net.minecraft.util.Identifier;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -132,5 +135,16 @@ public abstract class HandledScreenMixin extends Screen {
 				info.cancel();
 			}
 		}
+	}
+
+	@WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;mouseClicked(DDI)Z"), method = "mouseClicked")
+	private boolean overrideRecipeBookClick(HandledScreen<?> instance, double mouseX, double mouseY, int button, Operation<Boolean> original) {
+        if (TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY) && this.focusedSlot != null) {
+			Optional<Element> hoveredElement = this.hoveredElement(mouseX, mouseY);
+			if(hoveredElement.isPresent() && hoveredElement.get() instanceof ButtonWidget) {
+            	return false;
+			}
+        }
+		return original.call(instance, mouseX, mouseY, button);
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
@@ -5,6 +5,8 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import dev.emi.trinkets.TrinketScreenManager;
+import dev.emi.trinkets.TrinketsMain;
+import dev.emi.trinkets.api.TrinketInventory;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 import net.minecraft.client.render.RenderLayer;
@@ -38,6 +40,9 @@ import java.util.function.Function;
 public abstract class HandledScreenMixin extends Screen {
 	@Shadow @Nullable protected Slot focusedSlot;
 	@Shadow @Final private static Identifier SLOT_HIGHLIGHT_BACK_TEXTURE;
+
+	@Shadow protected abstract void resetTooltipSubmenus(Slot slot);
+
 	@Unique
 	private static final Identifier MORE_SLOTS = Identifier.of("trinkets", "textures/gui/more_slots.png");
 	@Unique
@@ -118,6 +123,18 @@ public abstract class HandledScreenMixin extends Screen {
 				} else if (slot.id != TrinketsClient.activeGroup.getSlotId()) {
 					info.setReturnValue(false);
 				}
+			}
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "resetTooltipSubmenus", cancellable = true)
+	private void resetTooltipSubmenus(Slot slot, CallbackInfo info) {
+		if (slot instanceof TrinketSlot && slot.inventory instanceof TrinketInventory inventory) {
+			if (slot.getIndex() >= inventory.size()) {
+				if (slot != this.focusedSlot && this.focusedSlot != null) {
+					this.resetTooltipSubmenus(this.focusedSlot);
+				}
+				info.cancel();
 			}
 		}
 	}

--- a/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/HandledScreenMixin.java
@@ -98,11 +98,6 @@ public abstract class HandledScreenMixin extends Screen {
 			context.getMatrices().translate(0, 0, 100 + 310 + 70 + 70 + 1);
 			original.call(context, renderLayers, sprite, x, y, width, height);
 			context.getMatrices().pop();
-		} else if (this.focusedSlot instanceof TrinketSlot) {
-			context.getMatrices().push();
-			context.getMatrices().translate(0, 0, 100 + 310 + 70 + 70 + 1);
-			original.call(context, renderLayers, sprite, x, y, width, height);
-			context.getMatrices().pop();
 		} else {
 			original.call(context, renderLayers, sprite, x, y, width, height);
 		}

--- a/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/InventoryScreenMixin.java
@@ -4,6 +4,7 @@ import dev.emi.trinkets.mixin.accessor.RecipeBookScreenAccessor;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.RecipeBookScreen;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -26,7 +27,8 @@ import net.minecraft.screen.slot.Slot;
  */
 @Mixin(InventoryScreen.class)
 public abstract class InventoryScreenMixin extends RecipeBookScreen<PlayerScreenHandler> implements RecipeBookProvider, TrinketScreen {
-	private InventoryScreenMixin() {
+
+    private InventoryScreenMixin() {
 		super(null, null, null, null);
 	}
 
@@ -88,5 +90,10 @@ public abstract class InventoryScreenMixin extends RecipeBookScreen<PlayerScreen
 	@Override
 	public boolean trinkets$isRecipeBookOpen() {
 		return ((RecipeBookScreenAccessor) this).getRecipeBook().isOpen();
+	}
+
+	@Override
+	public boolean trinkets$isNarrow() {
+		return (((RecipeBookScreenAccessor) this).getNarrow());
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -16,6 +16,7 @@ import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import dev.emi.trinkets.payload.SyncInventoryPayload;
 import net.minecraft.component.EnchantmentEffectComponentTypes;
 import dev.emi.trinkets.api.LivingEntityTrinketComponent;
+import dev.emi.trinkets.api.event.SlotCountModificationCallback;
 import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Pair;
@@ -170,9 +171,10 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 				}
 			});
 
+            Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
+
 			World world = this.getWorld();
 			if (!world.isClient) {
-				Set<TrinketInventory> inventoriesToSend = trinkets.getTrackingUpdates();
 
 				if (!contentUpdates.isEmpty() || !inventoriesToSend.isEmpty()) {
                     Map<String, NbtCompound> map = new HashMap<>();
@@ -184,9 +186,6 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 
 					for (ServerPlayerEntity player : PlayerLookup.tracking(entity)) {
 						ServerPlayNetworking.send(player, packet);
-                        if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
-                            screenHandler.trinkets$updateTrinketSlots(false);
-                        }
 					}
 
 					if (entity instanceof ServerPlayerEntity serverPlayer) {
@@ -196,10 +195,14 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 							((TrinketPlayerScreenHandler) serverPlayer.playerScreenHandler).trinkets$updateTrinketSlots(false);
 						}
 					}
-
-					inventoriesToSend.clear();
 				}
 			}
+
+			if (!inventoriesToSend.isEmpty()) {
+				SlotCountModificationCallback.EVENT.invoker().onChange(trinkets, inventoriesToSend);
+			}
+
+			inventoriesToSend.clear();
 
 			lastEquippedTrinkets.clear();
 			lastEquippedTrinkets.putAll(newlyEquippedTrinkets);

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -5,15 +5,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
 
-import dev.emi.trinkets.TrinketModifiers;
-import dev.emi.trinkets.api.SlotAttributes;
 import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.SlotType;
-import dev.emi.trinkets.api.Trinket;
 import dev.emi.trinkets.api.TrinketComponent;
 import dev.emi.trinkets.api.TrinketInventory;
 import dev.emi.trinkets.api.TrinketsApi;
@@ -21,13 +15,11 @@ import dev.emi.trinkets.api.event.TrinketEquipCallback;
 import dev.emi.trinkets.api.event.TrinketUnequipCallback;
 import dev.emi.trinkets.payload.SyncInventoryPayload;
 import net.minecraft.component.EnchantmentEffectComponentTypes;
-import net.minecraft.entity.attribute.EntityAttributeInstance;
-import net.minecraft.registry.entry.RegistryEntry;
+import dev.emi.trinkets.api.LivingEntityTrinketComponent;
 import net.minecraft.registry.tag.ItemTags;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Pair;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -35,7 +27,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import dev.emi.trinkets.TrinketPlayerScreenHandler;
-import dev.emi.trinkets.api.SlotAttributes.SlotEntityAttribute;
 import dev.emi.trinkets.api.TrinketEnums.DropRule;
 import dev.emi.trinkets.api.event.TrinketDropCallback;
 import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
@@ -45,14 +36,10 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.attribute.AttributeContainer;
-import net.minecraft.entity.attribute.EntityAttribute;
-import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 
@@ -65,9 +52,6 @@ import net.minecraft.world.World;
 public abstract class LivingEntityMixin extends Entity {
 	@Unique
 	private final Map<String, ItemStack> lastEquippedTrinkets = new HashMap<>();
-
-	@Shadow
-	public abstract AttributeContainer getAttributes();
 
 	private LivingEntityMixin() {
 		super(null, null);
@@ -167,66 +151,29 @@ public abstract class LivingEntityMixin extends Entity {
 					TrinketEquipCallback.EVENT.invoker().onEquip(newStack, ref, entity);
 
 					World world = this.getWorld();
-					if (!world.isClient) {
+					if (!world.isClient && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinkets) {
 						contentUpdates.put(newRef, newStackCopy);
 
 						if (!oldStack.isEmpty()) {
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(oldStack, ref, entity);
-							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
-							Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
-							for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
-								if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
-									slotMap.putAll(slotAttr.slot, map.get(attr));
-									toRemove.add(attr);
-								}
-							}
-							for (RegistryEntry<EntityAttribute> attr : toRemove) {
-								map.removeAll(attr);
-							}
-							//this.getAttributes().removeModifiers(map);
-							map.asMap().forEach((attribute, modifiers) -> {
-								EntityAttributeInstance entityAttributeInstance = this.getAttributes().getCustomInstance(attribute);
-								if (entityAttributeInstance != null) {
-									modifiers.forEach(modifier -> entityAttributeInstance.removeModifier(modifier.id()));
-								}
-							});
-
-							trinkets.removeModifiers(slotMap);
+							livingEntityTrinkets.removeSlotModifiers(oldStack, ref);
 						}
 
-						if (!newStack.isEmpty()) {
-							Multimap<RegistryEntry<EntityAttribute>, EntityAttributeModifier> map = TrinketModifiers.get(newStack, ref, entity);
-							Multimap<String, EntityAttributeModifier> slotMap = HashMultimap.create();
-							Set<RegistryEntry<EntityAttribute>> toRemove = Sets.newHashSet();
-							for (RegistryEntry<EntityAttribute> attr : map.keySet()) {
-								if (attr.hasKeyAndValue() && attr.value() instanceof SlotEntityAttribute slotAttr) {
-									slotMap.putAll(slotAttr.slot, map.get(attr));
-									toRemove.add(attr);
-								}
-							}
-							for (RegistryEntry<EntityAttribute> attr : toRemove) {
-								map.removeAll(attr);
-							}
-							//this.getAttributes().addTemporaryModifiers(map);
-							map.forEach((attribute, attributeModifier) -> {
-								EntityAttributeInstance entityAttributeInstance = this.getAttributes().getCustomInstance(attribute);
-								if (entityAttributeInstance != null) {
-									entityAttributeInstance.removeModifier(attributeModifier.id());
-									entityAttributeInstance.addTemporaryModifier(attributeModifier);
-								}
-
-							});
-							trinkets.addTemporaryModifiers(slotMap);
+						if (!newStack.isEmpty() && index < inventory.size()) {
+							livingEntityTrinkets.addSlotModifiers(newStack, ref);
 						}
 					}
 				}
-				TrinketsApi.getTrinket(newStack.getItem()).tick(newStack, ref, entity);
-				ItemStack tickedStack = inventory.getStack(index);
-				// Avoid calling equip/unequip on stacks that mutate themselves
-				if (tickedStack.getItem() == newStackCopy.getItem()) {
-					newlyEquippedTrinkets.put(newRef, tickedStack.copy());
-				} else {
-					newlyEquippedTrinkets.put(newRef, newStackCopy);
+
+				// Check that the inventory hasn't shrunk past the new stack
+				if (index < inventory.size()) {
+					TrinketsApi.getTrinket(newStack.getItem()).tick(newStack, ref, entity);
+					ItemStack tickedStack = inventory.getStack(index);
+					// Avoid calling equip/unequip on stacks that mutate themselves
+					if (tickedStack.getItem() == newStackCopy.getItem()) {
+						newlyEquippedTrinkets.put(newRef, tickedStack.copy());
+					} else {
+						newlyEquippedTrinkets.put(newRef, newStackCopy);
+					}
 				}
 			});
 

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -184,6 +184,9 @@ public abstract class LivingEntityMixin extends Entity implements LivingEntityTr
 
 					for (ServerPlayerEntity player : PlayerLookup.tracking(entity)) {
 						ServerPlayNetworking.send(player, packet);
+                        if (player.currentScreenHandler instanceof TrinketPlayerScreenHandler screenHandler && !screenHandler.equals(player.playerScreenHandler)) {
+                            screenHandler.trinkets$updateTrinketSlots(false);
+                        }
 					}
 
 					if (entity instanceof ServerPlayerEntity serverPlayer) {

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -49,7 +49,7 @@ import net.minecraft.world.World;
  * @author Emi
  */
 @Mixin(LivingEntity.class)
-public abstract class LivingEntityMixin extends Entity {
+public abstract class LivingEntityMixin extends Entity implements LivingEntityTrinketComponent.StackHistory {
 	@Unique
 	private final Map<String, ItemStack> lastEquippedTrinkets = new HashMap<>();
 
@@ -136,12 +136,11 @@ public abstract class LivingEntityMixin extends Entity {
 			Map<String, ItemStack> contentUpdates = new HashMap<>();
 			trinkets.forEach((ref, stack) -> {
 				TrinketInventory inventory = ref.inventory();
-				SlotType slotType = inventory.getSlotType();
 				int index = ref.index();
-				ItemStack oldStack = getOldStack(slotType, index);
+				ItemStack oldStack = trinkets$getOldStack(ref);
 				ItemStack newStack = inventory.getStack(index);
 				ItemStack newStackCopy = newStack.copy();
-				String newRef = slotType.getGroup() + "/" + slotType.getName() + "/" + index;
+				String newRef = ref.getId();
 
 				if (!ItemStack.areEqual(newStack, oldStack)) {
 
@@ -204,8 +203,8 @@ public abstract class LivingEntityMixin extends Entity {
 		});
 	}
 
-	@Unique
-	private ItemStack getOldStack(SlotType type, int index) {
-		return lastEquippedTrinkets.getOrDefault(type.getGroup() + "/" + type.getName() + "/" + index, ItemStack.EMPTY);
+	@Override
+	public ItemStack trinkets$getOldStack(SlotReference ref) {
+		return lastEquippedTrinkets.getOrDefault(ref.getId(), ItemStack.EMPTY);
 	}
 }

--- a/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/LivingEntityMixin.java
@@ -154,13 +154,7 @@ public abstract class LivingEntityMixin extends Entity {
 					if (!world.isClient && trinkets instanceof LivingEntityTrinketComponent livingEntityTrinkets) {
 						contentUpdates.put(newRef, newStackCopy);
 
-						if (!oldStack.isEmpty()) {
-							livingEntityTrinkets.removeSlotModifiers(oldStack, ref);
-						}
-
-						if (!newStack.isEmpty() && index < inventory.size()) {
-							livingEntityTrinkets.addSlotModifiers(newStack, ref);
-						}
+						livingEntityTrinkets.processSlotModifiers(ref, oldStack, newStack);
 					}
 				}
 

--- a/src/main/java/dev/emi/trinkets/mixin/RecipeBookScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/RecipeBookScreenMixin.java
@@ -1,10 +1,7 @@
 package dev.emi.trinkets.mixin;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.emi.trinkets.TrinketScreenManager;
 import net.minecraft.client.gui.screen.ingame.RecipeBookScreen;
-import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -17,13 +14,5 @@ public class RecipeBookScreenMixin {
         if (TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY)) {
             info.setReturnValue(false);
         }
-    }
-
-    @WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/recipebook/RecipeBookWidget;mouseClicked(DDI)Z"), method = "Lnet/minecraft/client/gui/screen/ingame/RecipeBookScreen;mouseClicked(DDI)Z")
-    private boolean overrideRecipeBookClick(RecipeBookWidget<?> instance, double mouseX, double mouseY, int button, Operation<Boolean> original) {
-        if (TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY)) {
-            return false;
-        }
-        return original.call(instance, mouseX, mouseY, button);
     }
 }

--- a/src/main/java/dev/emi/trinkets/mixin/RecipeBookScreenMixin.java
+++ b/src/main/java/dev/emi/trinkets/mixin/RecipeBookScreenMixin.java
@@ -1,7 +1,10 @@
 package dev.emi.trinkets.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import dev.emi.trinkets.TrinketScreenManager;
 import net.minecraft.client.gui.screen.ingame.RecipeBookScreen;
+import net.minecraft.client.gui.screen.recipebook.RecipeBookWidget;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,5 +17,13 @@ public class RecipeBookScreenMixin {
         if (TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY)) {
             info.setReturnValue(false);
         }
+    }
+
+    @WrapOperation(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/recipebook/RecipeBookWidget;mouseClicked(DDI)Z"), method = "Lnet/minecraft/client/gui/screen/ingame/RecipeBookScreen;mouseClicked(DDI)Z")
+    private boolean overrideRecipeBookClick(RecipeBookWidget<?> instance, double mouseX, double mouseY, int button, Operation<Boolean> original) {
+        if (TrinketScreenManager.isClickInsideTrinketBounds(mouseX, mouseY)) {
+            return false;
+        }
+        return original.call(instance, mouseX, mouseY, button);
     }
 }

--- a/src/main/java/dev/emi/trinkets/mixin/accessor/RecipeBookScreenAccessor.java
+++ b/src/main/java/dev/emi/trinkets/mixin/accessor/RecipeBookScreenAccessor.java
@@ -10,4 +10,6 @@ public interface RecipeBookScreenAccessor {
 
 	@Accessor
 	RecipeBookWidget<?> getRecipeBook();
+	@Accessor
+	boolean getNarrow();
 }


### PR DESCRIPTION
This PR contains many of the same changes as https://github.com/emilyploszaj/trinkets/pull/410#issue-4246419235, with most only undergoing changes to adapt the existing fixes.

A new fix is that TrinketSlots will only have their tooltip submenus reset if they still exist. If a slot were removed to this, then attempting to reset the submenu on loss of hover would crash the game.

The previous methods for suppressing the Recipe Book button in 1.20.1 no longer apply to the Recipe Book, and have been supplemented with preventing the ScreenHandler from registering mouseClicks on ButtonWidgets if a TrinketSlot is currently hovered.